### PR TITLE
Parse ignore files into sections

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,49 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestLoadIgnoreFilePatternsLegacy(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".ignore")
+	content := "# comment\nfoo\nbar\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write ignore file: %v", err)
+	}
+	patterns, err := LoadIgnoreFilePatterns(path)
+	if err != nil {
+		t.Fatalf("LoadIgnoreFilePatterns returned error: %v", err)
+	}
+	expectedIgnore := []string{"foo", "bar"}
+	if !reflect.DeepEqual(patterns.Ignore, expectedIgnore) {
+		t.Fatalf("unexpected ignore patterns: %#v", patterns.Ignore)
+	}
+	if len(patterns.Binary) != 0 {
+		t.Fatalf("expected no binary patterns, got %#v", patterns.Binary)
+	}
+}
+
+func TestLoadIgnoreFilePatternsWithSections(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".ignore")
+	content := "pre\n[binary]\nbin1\n[ignore]\nig1\n[binary]\nbin2\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write ignore file: %v", err)
+	}
+	patterns, err := LoadIgnoreFilePatterns(path)
+	if err != nil {
+		t.Fatalf("LoadIgnoreFilePatterns returned error: %v", err)
+	}
+	expectedIgnore := []string{"pre", "ig1"}
+	expectedBinary := []string{"bin1", "bin2"}
+	if !reflect.DeepEqual(patterns.Ignore, expectedIgnore) {
+		t.Fatalf("unexpected ignore patterns: %#v", patterns.Ignore)
+	}
+	if !reflect.DeepEqual(patterns.Binary, expectedBinary) {
+		t.Fatalf("unexpected binary patterns: %#v", patterns.Binary)
+	}
+}

--- a/tests/ctx_test.go
+++ b/tests/ctx_test.go
@@ -355,8 +355,8 @@ func TestCTX(testingHandle *testing.T) {
 				appTypes.FormatJSON,
 			},
 			prepare: func(t *testing.T) string {
-				if runtime.GOOS == "windows" {
-					t.Skip("Skipping unreadable file test on Windows")
+				if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+					t.Skip("Skipping unreadable file test on Windows or as root")
 				}
 				return setupTestDirectory(t, map[string]string{
 					"readable.txt":   "OK",


### PR DESCRIPTION
## Summary
- parse .ignore files with `[ignore]` and `[binary]` headers, collecting patterns separately
- handle new structured patterns when combining ignore rules
- add tests for ignore file parser and skip unreadable file test when running as root

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6893c2f2a9f48327adce6dfdb35e940c