### PR TITLE
refactor: centralize ignore file constants

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -8,13 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/temirov/ctx/types"
 	"github.com/temirov/ctx/utils"
-)
-
-const (
-	ignoreFileName    = ".ignore"
-	gitIgnoreFileName = ".gitignore"
-	exclusionPrefix   = "EXCL:"
 )
 
 // LoadIgnoreFilePatterns reads a specified ignore file (if it exists) and returns a slice of ignore patterns.
@@ -57,19 +52,19 @@ func LoadCombinedIgnorePatterns(absoluteDirectoryPath string, exclusionFolder st
 	var combinedPatterns []string
 
 	if useIgnoreFile {
-		ignoreFilePath := filepath.Join(absoluteDirectoryPath, ignoreFileName)
+		ignoreFilePath := filepath.Join(absoluteDirectoryPath, types.IgnoreFileName)
 		ignoreFilePatterns, loadError := LoadIgnoreFilePatterns(ignoreFilePath)
 		if loadError != nil {
-			return nil, fmt.Errorf("loading %s from %s: %w", ignoreFileName, absoluteDirectoryPath, loadError)
+			return nil, fmt.Errorf("loading %s from %s: %w", types.IgnoreFileName, absoluteDirectoryPath, loadError)
 		}
 		combinedPatterns = append(combinedPatterns, ignoreFilePatterns...)
 	}
 
 	if useGitignore {
-		gitIgnoreFilePath := filepath.Join(absoluteDirectoryPath, gitIgnoreFileName)
+		gitIgnoreFilePath := filepath.Join(absoluteDirectoryPath, types.GitIgnoreFileName)
 		gitignoreFilePatterns, loadError := LoadIgnoreFilePatterns(gitIgnoreFilePath)
 		if loadError != nil {
-			return nil, fmt.Errorf("loading %s from %s: %w", gitIgnoreFileName, absoluteDirectoryPath, loadError)
+			return nil, fmt.Errorf("loading %s from %s: %w", types.GitIgnoreFileName, absoluteDirectoryPath, loadError)
 		}
 		combinedPatterns = append(combinedPatterns, gitignoreFilePatterns...)
 	}
@@ -79,7 +74,7 @@ func LoadCombinedIgnorePatterns(absoluteDirectoryPath string, exclusionFolder st
 	trimmedExclusion := strings.TrimSpace(exclusionFolder)
 	if trimmedExclusion != "" {
 		normalizedExclusion := strings.TrimSuffix(trimmedExclusion, "/")
-		exclusionPattern := exclusionPrefix + normalizedExclusion
+		exclusionPattern := types.ExclusionPrefix + normalizedExclusion
 		isPresent := false
 		for _, pattern := range deduplicatedFilePatterns {
 			if pattern == exclusionPattern {

--- a/types/paths.go
+++ b/types/paths.go
@@ -1,0 +1,13 @@
+// Package types defines cross-package constants for file and path handling.
+package types
+
+const (
+	// IgnoreFileName is the name of the file containing ignore patterns.
+	IgnoreFileName = ".ignore"
+
+	// GitIgnoreFileName is the name of the Git ignore file containing ignore patterns.
+	GitIgnoreFileName = ".gitignore"
+
+	// ExclusionPrefix marks a pattern as an exclusion directive.
+	ExclusionPrefix = "EXCL:"
+)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -5,18 +5,13 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-)
 
-// Constants related to ignore file handling.
-const (
-	IgnoreFileName    = ".ignore"
-	GitIgnoreFileName = ".gitignore"
-	ExclusionPrefix   = "EXCL:"
+	"github.com/temirov/ctx/types"
 )
 
 var serviceFiles = map[string]struct{}{
-	IgnoreFileName:    {},
-	GitIgnoreFileName: {},
+	types.IgnoreFileName:    {},
+	types.GitIgnoreFileName: {},
 }
 
 // DeduplicatePatterns removes duplicate patterns from a slice while preserving order.
@@ -76,8 +71,8 @@ func ShouldIgnore(directoryEntry os.DirEntry, ignorePatterns []string, isRootLev
 	}
 
 	for _, patternValue := range ignorePatterns {
-		if strings.HasPrefix(patternValue, ExclusionPrefix) {
-			exclusionName := strings.TrimPrefix(patternValue, ExclusionPrefix)
+		if strings.HasPrefix(patternValue, types.ExclusionPrefix) {
+			exclusionName := strings.TrimPrefix(patternValue, types.ExclusionPrefix)
 			if isRootLevel && directoryEntry.IsDir() && entryName == exclusionName {
 				return true
 			}
@@ -115,8 +110,8 @@ func ShouldIgnoreByPath(relativePath string, ignorePatterns []string) bool {
 	}
 
 	for _, pattern := range ignorePatterns {
-		if strings.HasPrefix(pattern, ExclusionPrefix) {
-			exclusionName := strings.TrimPrefix(pattern, ExclusionPrefix)
+		if strings.HasPrefix(pattern, types.ExclusionPrefix) {
+			exclusionName := strings.TrimPrefix(pattern, types.ExclusionPrefix)
 			if len(pathComponents) >= 1 && pathComponents[0] == exclusionName {
 				return true
 			}


### PR DESCRIPTION
## Summary
- add shared path constants for ignore files and exclusion prefix
- refactor config and utils packages to use shared constants

## Testing
- `go test ./...` *(fails: expected warnings for unreadable file when running tests as root)*

------
https://chatgpt.com/codex/tasks/task_e_68b9cba58f2c8327976390ef3d9af529