### PR TITLE
Add XML output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ and **optional embedded documentation** for referenced packages and symbols.
 - **Embedded Documentation (`--doc`):** When the `--doc` flag is used with the `content` or `callchain` command,
   ctx embeds documentation for imported third-party packages and referenced functions in the output (both *raw* and
   *json* formats).
-- **Output Formats:** Supports **raw** text output (default) and **json** output using the `--format` flag for all
+- **Output Formats:** Supports **raw** text output (default), **json**, and **xml** output using the `--format` flag for all
   commands.
 - **Tree Command (`tree`, `t`):**
     - *Raw format:* Recursively displays the directory structure for each specified directory in a tree-like format,
@@ -82,7 +82,7 @@ ctx <tree|t|content|c|callchain|cc> [arguments...] [flags]
 | `--no-gitignore`      | tree, content      | Disable loading of `.gitignore` files. |
 | `--no-ignore`         | tree, content      | Disable loading of `.ignore` files. |
 | `--git`               | tree, content      | Include the `.git` directory during traversal. |
-| `--format <raw|json>` | all commands       | Select output format (default `raw`). |
+| `--format <raw|json|xml>` | all commands       | Select output format (default `raw`). |
 | `--doc`               | content, callchain | Embed documentation for referenced external packages and symbols into the output. |
 | `--version`           | all commands       | Print ctx version and exit. |
 
@@ -112,6 +112,7 @@ ctx callchain github.com/temirov/ctx/internal/commands.GetContentData --doc --fo
 |--------|--------------------------------|--------------------------------------------|------------------|
 | raw    | Text tree view (`[File] path`) | File blocks (`File: path ... End of file`) | Metadata, source blocks; docs when `--doc`. |
 | json   | `[]TreeOutputNode`             | `[]FileOutput`                             | `CallChainOutput` |
+| xml    | `result/code/item` nodes       | `result/code/item` nodes                   | `callchains/callchain` |
 
 ## Configuration
 

--- a/cmd/ctx/main.go
+++ b/cmd/ctx/main.go
@@ -94,7 +94,7 @@ func createTreeCommand() *cobra.Command {
 				withDocumentation = false
 			}
 			outputFormatLower := strings.ToLower(outputFormat)
-			if outputFormatLower != types.FormatRaw && outputFormatLower != types.FormatJSON {
+			if outputFormatLower != types.FormatRaw && outputFormatLower != types.FormatJSON && outputFormatLower != types.FormatXML {
 				return fmt.Errorf("Invalid format value '%s'", outputFormatLower)
 			}
 			return runTool(
@@ -138,7 +138,7 @@ func createContentCommand() *cobra.Command {
 				arguments = []string{defaultPath}
 			}
 			outputFormatLower := strings.ToLower(outputFormat)
-			if outputFormatLower != types.FormatRaw && outputFormatLower != types.FormatJSON {
+			if outputFormatLower != types.FormatRaw && outputFormatLower != types.FormatJSON && outputFormatLower != types.FormatXML {
 				return fmt.Errorf("Invalid format value '%s'", outputFormatLower)
 			}
 			return runTool(
@@ -175,7 +175,7 @@ func createCallChainCommand() *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 		RunE: func(command *cobra.Command, arguments []string) error {
 			outputFormatLower := strings.ToLower(outputFormat)
-			if outputFormatLower != types.FormatRaw && outputFormatLower != types.FormatJSON {
+			if outputFormatLower != types.FormatRaw && outputFormatLower != types.FormatJSON && outputFormatLower != types.FormatXML {
 				return fmt.Errorf("Invalid format value '%s'", outputFormatLower)
 			}
 			return runTool(
@@ -241,6 +241,12 @@ func runCallChain(
 	}
 	if format == types.FormatJSON {
 		out, err := output.RenderCallChainJSON(data)
+		if err != nil {
+			return err
+		}
+		fmt.Println(out)
+	} else if format == types.FormatXML {
+		out, err := output.RenderCallChainXML(data)
 		if err != nil {
 			return err
 		}
@@ -340,6 +346,13 @@ func runTreeOrContentCommand(
 
 	if format == types.FormatJSON {
 		out, err := output.RenderJSON(documentationEntries, collected)
+		if err != nil {
+			return err
+		}
+		fmt.Println(out)
+		return nil
+	} else if format == types.FormatXML {
+		out, err := output.RenderXML(documentationEntries, collected)
 		if err != nil {
 			return err
 		}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -12,6 +12,7 @@ const (
 
 	FormatRaw  = "raw"
 	FormatJSON = "json"
+	FormatXML  = "xml"
 )
 
 // ValidatedPath is an absolute input path that already passed existence checks.
@@ -22,32 +23,32 @@ type ValidatedPath struct {
 
 // DocumentationEntry is a single piece of documentation attached to output.
 type DocumentationEntry struct {
-	Kind string `json:"type"`
-	Name string `json:"name"`
-	Doc  string `json:"documentation"`
+	Kind string `json:"type" xml:"type"`
+	Name string `json:"name" xml:"name"`
+	Doc  string `json:"documentation" xml:"documentation"`
 }
 
 // FileOutput represents one file returned by the content command.
 type FileOutput struct {
-	Path          string               `json:"path"`
-	Type          string               `json:"type"`
-	Content       string               `json:"content"`
-	Documentation []DocumentationEntry `json:"documentation,omitempty"`
+	Path          string               `json:"path" xml:"path"`
+	Type          string               `json:"type" xml:"type"`
+	Content       string               `json:"content" xml:"content"`
+	Documentation []DocumentationEntry `json:"documentation,omitempty" xml:"documentation>entry,omitempty"`
 }
 
 // TreeOutputNode represents a node of a directory tree returned by the tree command.
 type TreeOutputNode struct {
-	Path     string            `json:"path"`
-	Name     string            `json:"name"`
-	Type     string            `json:"type"`
-	Children []*TreeOutputNode `json:"children,omitempty"`
+	Path     string            `json:"path" xml:"path"`
+	Name     string            `json:"name" xml:"name"`
+	Type     string            `json:"type" xml:"type"`
+	Children []*TreeOutputNode `json:"children,omitempty" xml:"children>node,omitempty"`
 }
 
 // CallChainOutput is the result of the callchain command.
 type CallChainOutput struct {
-	TargetFunction string               `json:"targetFunction"`
-	Callers        []string             `json:"callers"`
-	Callees        *[]string            `json:"callees,omitempty"`
-	Functions      map[string]string    `json:"functions"`
-	Documentation  []DocumentationEntry `json:"documentation,omitempty"`
+	TargetFunction string               `json:"targetFunction" xml:"targetFunction"`
+	Callers        []string             `json:"callers" xml:"callers>caller"`
+	Callees        *[]string            `json:"callees,omitempty" xml:"callees>callee,omitempty"`
+	Functions      map[string]string    `json:"functions" xml:"-"`
+	Documentation  []DocumentationEntry `json:"documentation,omitempty" xml:"documentation>entry,omitempty"`
 }

--- a/tests/ctx_test.go
+++ b/tests/ctx_test.go
@@ -4,6 +4,7 @@ package tests
 import (
 	"bytes"
 	"encoding/json"
+	"encoding/xml"
 	"errors"
 	"os"
 	"os/exec"
@@ -277,6 +278,58 @@ func TestCTX(testingHandle *testing.T) {
 			},
 		},
 		{
+			name: "TreeXML",
+			arguments: []string{
+				appTypes.CommandTree,
+				"fileA.txt",
+				"--format",
+				appTypes.FormatXML,
+			},
+			prepare: func(t *testing.T) string {
+				return setupTestDirectory(t, map[string]string{
+					"fileA.txt": "A",
+				})
+			},
+			validate: func(t *testing.T, output string) {
+				type resultWrapper struct {
+					Nodes []appTypes.TreeOutputNode `xml:"code>item"`
+				}
+				var wrapper resultWrapper
+				if err := xml.Unmarshal([]byte(output), &wrapper); err != nil {
+					t.Fatalf("invalid XML: %v\n%s", err, output)
+				}
+				if len(wrapper.Nodes) != 1 {
+					t.Fatalf("expected one top-level node, got %d", len(wrapper.Nodes))
+				}
+			},
+		},
+		{
+			name: "ContentXML",
+			arguments: []string{
+				appTypes.CommandContent,
+				"fileA.txt",
+				"--format",
+				appTypes.FormatXML,
+			},
+			prepare: func(t *testing.T) string {
+				return setupTestDirectory(t, map[string]string{
+					"fileA.txt": "Content A",
+				})
+			},
+			validate: func(t *testing.T, output string) {
+				type resultWrapper struct {
+					Files []appTypes.FileOutput `xml:"code>item"`
+				}
+				var wrapper resultWrapper
+				if err := xml.Unmarshal([]byte(output), &wrapper); err != nil {
+					t.Fatalf("invalid XML: %v\n%s", err, output)
+				}
+				if len(wrapper.Files) != 1 {
+					t.Fatalf("expected one item, got %d", len(wrapper.Files))
+				}
+			},
+		},
+		{
 			name: "RawFormatExplicitFlag",
 			arguments: []string{
 				appTypes.CommandContent,
@@ -355,6 +408,34 @@ func TestCTX(testingHandle *testing.T) {
 				chain := list[0]
 				if chain.TargetFunction != contentDataFunction {
 					t.Fatalf("unexpected target function %q", chain.TargetFunction)
+				}
+			},
+		},
+		{
+			name: "CallChainXML",
+			arguments: []string{
+				appTypes.CommandCallChain,
+				contentDataFunction,
+				"--format",
+				appTypes.FormatXML,
+			},
+			prepare: func(t *testing.T) string { return getModuleRoot(t) },
+			validate: func(t *testing.T, output string) {
+				type callChainsWrapper struct {
+					XMLName xml.Name `xml:"callchains"`
+					Chains  []struct {
+						TargetFunction string `xml:"targetFunction"`
+					} `xml:"callchain"`
+				}
+				var wrapper callChainsWrapper
+				if err := xml.Unmarshal([]byte(output), &wrapper); err != nil {
+					t.Fatalf("invalid XML: %v\n%s", err, output)
+				}
+				if len(wrapper.Chains) == 0 {
+					t.Fatalf("expected at least one element, got zero")
+				}
+				if wrapper.Chains[0].TargetFunction != contentDataFunction {
+					t.Fatalf("unexpected target function %q", wrapper.Chains[0].TargetFunction)
 				}
 			},
 		},


### PR DESCRIPTION
## Summary
- add XML rendering for tree, content, and callchain commands
- expose `--format xml` flag
- document XML output in README and tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b9fb7f0fe883279ff0cd7308268fae