### PR TITLE
Add MIME type reporting for binary files

### DIFF
--- a/cmd/ctx/main.go
+++ b/cmd/ctx/main.go
@@ -292,13 +292,16 @@ func runTreeOrContentCommand(
 		} else {
 			if commandName == types.CommandTree {
 				nodeType := types.NodeTypeFile
+				mimeType := ""
 				if utils.IsFileBinary(info.AbsolutePath) {
 					nodeType = types.NodeTypeBinary
+					mimeType = utils.DetectMimeType(info.AbsolutePath)
 				}
 				collected = append(collected, &types.TreeOutputNode{
-					Path: info.AbsolutePath,
-					Name: filepath.Base(info.AbsolutePath),
-					Type: nodeType,
+					Path:     info.AbsolutePath,
+					Name:     filepath.Base(info.AbsolutePath),
+					Type:     nodeType,
+					MimeType: mimeType,
 				})
 			} else {
 				data, err := os.ReadFile(info.AbsolutePath)
@@ -307,15 +310,18 @@ func runTreeOrContentCommand(
 					continue
 				}
 				fileType := types.NodeTypeFile
-				content := string(data)
+				fileContent := string(data)
+				mimeType := ""
 				if utils.IsBinary(data) {
 					fileType = types.NodeTypeBinary
-					content = ""
+					fileContent = ""
+					mimeType = utils.DetectMimeType(info.AbsolutePath)
 				}
 				collected = append(collected, &types.FileOutput{
-					Path:    info.AbsolutePath,
-					Type:    fileType,
-					Content: content,
+					Path:     info.AbsolutePath,
+					Type:     fileType,
+					MimeType: mimeType,
+					Content:  fileContent,
 				})
 			}
 		}

--- a/internal/commands/content.go
+++ b/internal/commands/content.go
@@ -49,16 +49,19 @@ func GetContentData(rootPath string, ignorePatterns []string) ([]types.FileOutpu
 		}
 
 		fileType := types.NodeTypeFile
-		content := string(contentBytes)
+		fileContent := string(contentBytes)
+		mimeType := ""
 		if utils.IsBinary(contentBytes) {
 			fileType = types.NodeTypeBinary
-			content = ""
+			fileContent = ""
+			mimeType = utils.DetectMimeType(currentPath)
 		}
 
 		fileOutputs = append(fileOutputs, types.FileOutput{
-			Path:    currentPath,
-			Type:    fileType,
-			Content: content,
+			Path:     currentPath,
+			Type:     fileType,
+			MimeType: mimeType,
+			Content:  fileContent,
 		})
 		return nil
 	})

--- a/internal/commands/tree.go
+++ b/internal/commands/tree.go
@@ -57,9 +57,9 @@ func buildTreeNodes(currentDirectoryPath string, rootDirectoryPath string, ignor
 
 		if entry.IsDir() {
 			node.Type = types.NodeTypeDirectory
-			childNodes, err := buildTreeNodes(childPath, rootDirectoryPath, ignorePatterns)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: Skipping subdirectory %s due to error: %v\n", childPath, err)
+			childNodes, buildError := buildTreeNodes(childPath, rootDirectoryPath, ignorePatterns)
+			if buildError != nil {
+				fmt.Fprintf(os.Stderr, "Warning: Skipping subdirectory %s due to error: %v\n", childPath, buildError)
 				node.Children = nil
 			} else {
 				node.Children = childNodes
@@ -67,6 +67,7 @@ func buildTreeNodes(currentDirectoryPath string, rootDirectoryPath string, ignor
 		} else {
 			if utils.IsFileBinary(childPath) {
 				node.Type = types.NodeTypeBinary
+				node.MimeType = utils.DetectMimeType(childPath)
 			} else {
 				node.Type = types.NodeTypeFile
 			}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -17,6 +17,8 @@ const (
 	callchainMetaHdr = "----- CALLCHAIN METADATA -----"
 	callchainFuncHdr = "----- FUNCTIONS -----"
 	callchainDocsHdr = "--- DOCS ---"
+	binaryOmittedFmt = "(binary %s content omitted)"
+	binaryNodeFmt    = "[Binary %s] %s"
 )
 
 // RenderCallChainRaw returns the call‑chain output in raw text format.
@@ -116,7 +118,7 @@ func RenderRaw(commandName string, documentationEntries []types.DocumentationEnt
 			if commandName == types.CommandContent {
 				fmt.Printf("File: %s\n", v.Path)
 				if v.Type == types.NodeTypeBinary {
-					fmt.Println("(binary content omitted)")
+					fmt.Printf(binaryOmittedFmt+"\n", v.MimeType)
 				} else {
 					fmt.Println(v.Content)
 				}
@@ -128,7 +130,7 @@ func RenderRaw(commandName string, documentationEntries []types.DocumentationEnt
 				if v.Type == types.NodeTypeFile {
 					fmt.Printf("[File] %s\n", v.Path)
 				} else if v.Type == types.NodeTypeBinary {
-					fmt.Printf("[Binary] %s\n", v.Path)
+					fmt.Printf(binaryNodeFmt+"\n", v.MimeType, v.Path)
 				} else {
 					fmt.Printf("\n--- Directory Tree: %s ---\n", v.Path)
 					printTree(v, "")
@@ -189,7 +191,7 @@ func printTree(node *types.TreeOutputNode, prefix string) {
 		fmt.Printf("%s[File] %s\n", prefix, node.Path)
 		return
 	case types.NodeTypeBinary:
-		fmt.Printf("%s[Binary] %s\n", prefix, node.Path)
+		fmt.Printf("%s"+binaryNodeFmt+"\n", prefix, node.MimeType, node.Path)
 		return
 	}
 	fmt.Printf("%s%s\n", prefix, node.Path)

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -29,17 +29,21 @@ type DocumentationEntry struct {
 
 // FileOutput represents one file returned by the content command.
 type FileOutput struct {
-	Path          string               `json:"path"`
-	Type          string               `json:"type"`
+	Path string `json:"path"`
+	Type string `json:"type"`
+	// MimeType is the MIME type of the file when the type is NodeTypeBinary.
+	MimeType      string               `json:"mimeType,omitempty"`
 	Content       string               `json:"content"`
 	Documentation []DocumentationEntry `json:"documentation,omitempty"`
 }
 
 // TreeOutputNode represents a node of a directory tree returned by the tree command.
 type TreeOutputNode struct {
-	Path     string            `json:"path"`
-	Name     string            `json:"name"`
-	Type     string            `json:"type"`
+	Path string `json:"path"`
+	Name string `json:"name"`
+	Type string `json:"type"`
+	// MimeType is the MIME type when the node represents binary content.
+	MimeType string            `json:"mimeType,omitempty"`
 	Children []*TreeOutputNode `json:"children,omitempty"`
 }
 

--- a/internal/utils/mime.go
+++ b/internal/utils/mime.go
@@ -1,0 +1,26 @@
+package utils
+
+import (
+	"io"
+	"net/http"
+	"os"
+)
+
+// DetectMimeType returns the MIME type of the file at filePath.
+// It reads up to sniffLen bytes and uses http.DetectContentType.
+// If the file cannot be read, an empty string is returned.
+func DetectMimeType(filePath string) string {
+	fileHandle, openError := os.Open(filePath)
+	if openError != nil {
+		return ""
+	}
+	defer fileHandle.Close()
+
+	buffer := make([]byte, sniffLen)
+	bytesRead, readError := fileHandle.Read(buffer)
+	if readError != nil && readError != io.EOF {
+		return ""
+	}
+
+	return http.DetectContentType(buffer[:bytesRead])
+}

--- a/tests/ctx_test.go
+++ b/tests/ctx_test.go
@@ -32,6 +32,7 @@ const (
 	dependencyFileContent = "dependency"
 	buildTargetPath       = "./cmd/ctx"
 	contentDataFunction   = "github.com/temirov/ctx/internal/commands.GetContentData"
+	binaryMimeType        = "application/octet-stream"
 )
 
 // buildBinary compiles the ctx binary and returns its path.
@@ -425,6 +426,9 @@ func TestCTX(testingHandle *testing.T) {
 				if files[0].Content != "" {
 					t.Fatalf("expected empty content for binary file, got %q", files[0].Content)
 				}
+				if files[0].MimeType != binaryMimeType {
+					t.Fatalf("expected MIME type %q, got %q", binaryMimeType, files[0].MimeType)
+				}
 			},
 		},
 		{
@@ -452,6 +456,9 @@ func TestCTX(testingHandle *testing.T) {
 				child := nodes[0].Children[0]
 				if child.Type != appTypes.NodeTypeBinary {
 					t.Fatalf("expected type %q, got %q", appTypes.NodeTypeBinary, child.Type)
+				}
+				if child.MimeType != binaryMimeType {
+					t.Fatalf("expected MIME type %q, got %q", binaryMimeType, child.MimeType)
 				}
 			},
 		},


### PR DESCRIPTION
## Summary
- detect file MIME types using a new `DetectMimeType` helper
- carry MIME type metadata in `FileOutput` and `TreeOutputNode`
- show binary MIME types in raw output

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b9fc4aa7b88327b36abe363941c093