### PR TITLE
Add MIME type detection for binary files

### DIFF
--- a/cmd/ctx/main.go
+++ b/cmd/ctx/main.go
@@ -298,13 +298,16 @@ func runTreeOrContentCommand(
 		} else {
 			if commandName == types.CommandTree {
 				nodeType := types.NodeTypeFile
+				mimeType := ""
 				if utils.IsFileBinary(info.AbsolutePath) {
 					nodeType = types.NodeTypeBinary
+					mimeType = utils.DetectMimeType(info.AbsolutePath)
 				}
 				collected = append(collected, &types.TreeOutputNode{
-					Path: info.AbsolutePath,
-					Name: filepath.Base(info.AbsolutePath),
-					Type: nodeType,
+					Path:     info.AbsolutePath,
+					Name:     filepath.Base(info.AbsolutePath),
+					Type:     nodeType,
+					MimeType: mimeType,
 				})
 			} else {
 				data, err := os.ReadFile(info.AbsolutePath)
@@ -314,14 +317,17 @@ func runTreeOrContentCommand(
 				}
 				fileType := types.NodeTypeFile
 				content := string(data)
+				mimeType := ""
 				if utils.IsBinary(data) {
 					fileType = types.NodeTypeBinary
 					content = ""
+					mimeType = utils.DetectMimeType(info.AbsolutePath)
 				}
 				collected = append(collected, &types.FileOutput{
-					Path:    info.AbsolutePath,
-					Type:    fileType,
-					Content: content,
+					Path:     info.AbsolutePath,
+					Type:     fileType,
+					Content:  content,
+					MimeType: mimeType,
 				})
 			}
 		}

--- a/internal/commands/content.go
+++ b/internal/commands/content.go
@@ -50,15 +50,18 @@ func GetContentData(rootPath string, ignorePatterns []string) ([]types.FileOutpu
 
 		fileType := types.NodeTypeFile
 		content := string(contentBytes)
+		mimeType := ""
 		if utils.IsBinary(contentBytes) {
 			fileType = types.NodeTypeBinary
 			content = ""
+			mimeType = utils.DetectMimeType(currentPath)
 		}
 
 		fileOutputs = append(fileOutputs, types.FileOutput{
-			Path:    currentPath,
-			Type:    fileType,
-			Content: content,
+			Path:     currentPath,
+			Type:     fileType,
+			Content:  content,
+			MimeType: mimeType,
 		})
 		return nil
 	})

--- a/internal/commands/tree.go
+++ b/internal/commands/tree.go
@@ -67,6 +67,7 @@ func buildTreeNodes(currentDirectoryPath string, rootDirectoryPath string, ignor
 		} else {
 			if utils.IsFileBinary(childPath) {
 				node.Type = types.NodeTypeBinary
+				node.MimeType = utils.DetectMimeType(childPath)
 			} else {
 				node.Type = types.NodeTypeFile
 			}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -26,6 +26,10 @@ const (
 	xmlItemName           = "item"
 	xmlCallchainsName     = "callchains"
 	xmlCallchainName      = "callchain"
+	binaryContentOmitted  = "(binary content omitted)"
+	mimeTypeLabel         = "Mime Type: "
+	binaryNodeFormat      = "[Binary] %s (%s%s)\n"
+	binaryTreeFormat      = "%s[Binary] %s (%s%s)\n"
 )
 
 // RenderCallChainRaw returns the call‑chain output in raw text format.
@@ -193,7 +197,8 @@ func RenderRaw(commandName string, documentationEntries []types.DocumentationEnt
 			if commandName == types.CommandContent {
 				fmt.Printf("File: %s\n", v.Path)
 				if v.Type == types.NodeTypeBinary {
-					fmt.Println("(binary content omitted)")
+					fmt.Printf("%s%s\n", mimeTypeLabel, v.MimeType)
+					fmt.Println(binaryContentOmitted)
 				} else {
 					fmt.Println(v.Content)
 				}
@@ -205,7 +210,7 @@ func RenderRaw(commandName string, documentationEntries []types.DocumentationEnt
 				if v.Type == types.NodeTypeFile {
 					fmt.Printf("[File] %s\n", v.Path)
 				} else if v.Type == types.NodeTypeBinary {
-					fmt.Printf("[Binary] %s\n", v.Path)
+					fmt.Printf(binaryNodeFormat, v.Path, mimeTypeLabel, v.MimeType)
 				} else {
 					fmt.Printf("\n--- Directory Tree: %s ---\n", v.Path)
 					printTree(v, "")
@@ -266,7 +271,7 @@ func printTree(node *types.TreeOutputNode, prefix string) {
 		fmt.Printf("%s[File] %s\n", prefix, node.Path)
 		return
 	case types.NodeTypeBinary:
-		fmt.Printf("%s[Binary] %s\n", prefix, node.Path)
+		fmt.Printf(binaryTreeFormat, prefix, node.Path, mimeTypeLabel, node.MimeType)
 		return
 	}
 	fmt.Printf("%s%s\n", prefix, node.Path)

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -33,6 +33,7 @@ type FileOutput struct {
 	Path          string               `json:"path" xml:"path"`
 	Type          string               `json:"type" xml:"type"`
 	Content       string               `json:"content" xml:"content"`
+	MimeType      string               `json:"mimeType,omitempty" xml:"mimeType,omitempty"`
 	Documentation []DocumentationEntry `json:"documentation,omitempty" xml:"documentation>entry,omitempty"`
 }
 
@@ -41,6 +42,7 @@ type TreeOutputNode struct {
 	Path     string            `json:"path" xml:"path"`
 	Name     string            `json:"name" xml:"name"`
 	Type     string            `json:"type" xml:"type"`
+	MimeType string            `json:"mimeType,omitempty" xml:"mimeType,omitempty"`
 	Children []*TreeOutputNode `json:"children,omitempty" xml:"children>node,omitempty"`
 }
 

--- a/internal/utils/mime.go
+++ b/internal/utils/mime.go
@@ -1,0 +1,28 @@
+package utils
+
+import (
+	"io"
+	"net/http"
+	"os"
+)
+
+const unknownMimeType = ""
+
+// DetectMimeType determines the MIME type of the file at the provided path by
+// reading up to sniffLen bytes and passing them to http.DetectContentType. It
+// returns an empty string if the file cannot be read.
+func DetectMimeType(filePath string) string {
+	openedFile, openError := os.Open(filePath)
+	if openError != nil {
+		return unknownMimeType
+	}
+	defer openedFile.Close()
+
+	buffer := make([]byte, sniffLen)
+	bytesRead, readError := openedFile.Read(buffer)
+	if readError != nil && readError != io.EOF {
+		return unknownMimeType
+	}
+
+	return http.DetectContentType(buffer[:bytesRead])
+}


### PR DESCRIPTION
## Summary
- detect file MIME types using `http.DetectContentType`
- extend output data types with `MimeType` and populate for binary files
- display MIME type in raw output when binary content is encountered

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b9ff10acb88327b63aa79c8ed3ca45