### PR TITLE
Support binary content directives

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -145,3 +145,22 @@ func ShouldIgnoreByPath(relativePath string, ignorePatterns []string) bool {
 
 	return false
 }
+
+// ShouldDisplayBinaryContentByPath checks if a path should reveal binary content based on binary content patterns.
+func ShouldDisplayBinaryContentByPath(relativePath string, binaryContentPatterns []string) bool {
+	normalizedPath := filepath.ToSlash(relativePath)
+	for _, patternValue := range binaryContentPatterns {
+		trimmedPattern := strings.TrimSuffix(patternValue, "/")
+		if strings.HasSuffix(patternValue, "/") {
+			if normalizedPath == trimmedPattern || strings.HasPrefix(normalizedPath, trimmedPattern+"/") {
+				return true
+			}
+			continue
+		}
+		isMatched, _ := filepath.Match(patternValue, normalizedPath)
+		if isMatched {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- parse `.ignore` directives prefixed with `show-binary-content:` and propagate binary content patterns
- allow content and tree commands to receive binary content patterns and base64 encode matched binaries
- add utility for path-based binary content display and expand tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ba0099e4ac83279245d3634e757f19