### PR TITLE
docs: document binary file handling

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -72,6 +72,41 @@ optional global exclusion flag (`-e`/`--e`). Explicitly listed files are never f
     - Uses standard Gitignore semantics (glob patterns). One pattern per line. Non-empty lines not beginning with `#`
       considered.
 
+### Binary Content Handling
+
+- When the `content` command encounters a binary file, it records the MIME type and omits the content. This occurs when `.ignore` contains no directives:
+
+  ```
+  # .ignore
+  # (no show-binary-content directives)
+  ```
+
+  ```bash
+  ctx content image.png --format raw
+  File: image.png
+  Mime Type: image/png
+  (binary content omitted)
+  End of file: image.png
+  ```
+
+- Lines in `.ignore` prefixed with `show-binary-content:` list paths whose binary contents are base64-encoded and included in output:
+
+  ```
+  show-binary-content: image.png
+  ```
+
+  ```bash
+  ctx content . --format json
+  [
+    {
+      "path": "image.png",
+      "type": "binary",
+      "content": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PdpvJwAAAABJRU5ErkJggg==",
+      "mimeType": "image/png"
+    }
+  ]
+  ```
+
 ### Error Handling
 
 - Invalid command or flag combinations cause immediate program termination with usage info.

--- a/README.md
+++ b/README.md
@@ -119,10 +119,40 @@ ctx callchain github.com/temirov/ctx/internal/commands.GetContentData --doc --fo
 
 Exclusion patterns are loaded **only** during directory traversal; explicitly listed file paths are never ignored.
 
-Lines in `.ignore` starting with `show-binary-content:` mark paths whose binary contents are base64-encoded and included in output:
+## Binary File Handling
+
+When a binary file is encountered, `ctx` reports its MIME type and omits the content. This is the default behavior when `.ignore` contains no directives:
 
 ```
-show-binary-content: assets/logo.png
+# .ignore
+# (no show-binary-content directives)
+```
+
+```bash
+ctx content image.png --format raw
+File: image.png
+Mime Type: image/png
+(binary content omitted)
+End of file: image.png
+```
+
+To include binary data, add a `show-binary-content:` directive to `.ignore`. Matched files are emitted as base64-encoded strings:
+
+```
+# .ignore
+show-binary-content: image.png
+```
+
+```bash
+ctx content . --format json
+[
+  {
+    "path": "image.png",
+    "type": "binary",
+    "content": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PdpvJwAAAABJRU5ErkJggg==",
+    "mimeType": "image/png"
+  }
+]
 ```
 
 ## License


### PR DESCRIPTION
## Summary
- clarify default omission of binary content and MIME-type display
- describe `show-binary-content:` directive with examples
- add example CLI outputs for both default and base64 behaviors

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ba05870b288327897ffa908fd86f2c