### PR TITLE
feat: show binary mime type and content

### DIFF
--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -198,7 +198,11 @@ func RenderRaw(commandName string, documentationEntries []types.DocumentationEnt
 				fmt.Printf("File: %s\n", v.Path)
 				if v.Type == types.NodeTypeBinary {
 					fmt.Printf("%s%s\n", mimeTypeLabel, v.MimeType)
-					fmt.Println(binaryContentOmitted)
+					if v.Content == "" {
+						fmt.Println(binaryContentOmitted)
+					} else {
+						fmt.Println(v.Content)
+					}
 				} else {
 					fmt.Println(v.Content)
 				}


### PR DESCRIPTION
## Summary
- add binary omission and MIME type labels
- display MIME type and optional binary content in raw output
- include MIME type when rendering binary nodes in trees

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ba057faa808327b111bba407d4ad6b