### PR TITLE
fix: show help when no command provided

### DIFF
--- a/cmd/ctx/main.go
+++ b/cmd/ctx/main.go
@@ -54,7 +54,9 @@ func createRootCommand() *cobra.Command {
 		Use:          rootUse,
 		Short:        rootShortDescription,
 		SilenceUsage: true,
-		Run:          func(command *cobra.Command, arguments []string) {},
+		RunE: func(command *cobra.Command, arguments []string) error {
+			return command.Help()
+		},
 		PersistentPreRun: func(command *cobra.Command, arguments []string) {
 			if showVersion {
 				fmt.Printf(versionTemplate, utils.GetApplicationVersion())

--- a/tests/ctx_test.go
+++ b/tests/ctx_test.go
@@ -36,6 +36,8 @@ const (
 	integrationBinaryBaseName    = "ctx_integration_binary"
 	contentDataFunction          = "github.com/temirov/ctx/internal/commands.GetContentData"
 
+	usageSnippet = "Usage:\n  ctx"
+
 	binaryFixtureFileName      = "fixture.png"
 	expectedBinaryMimeType     = "image/png"
 	ignoreFileName             = ".ignore"
@@ -218,6 +220,16 @@ func TestCTX(testingHandle *testing.T) {
 		expectWarning bool
 		validate      func(*testing.T, string)
 	}{
+		{
+			name:      "NoArgumentsDisplaysHelp",
+			arguments: nil,
+			prepare:   func(testingHandle *testing.T) string { return setupTestDirectory(testingHandle, nil) },
+			validate: func(testingHandle *testing.T, output string) {
+				if !strings.Contains(output, usageSnippet) {
+					testingHandle.Fatalf("expected help output containing %q\n%s", usageSnippet, output)
+				}
+			},
+		},
 		{
 			name: "DocFlagCallChainRaw",
 			arguments: []string{


### PR DESCRIPTION
## Summary
- ensure root command prints help when no subcommand is specified
- add regression test for help output when running without arguments

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ba0962022883279e65a1f019aaba3a