### PR TITLE
refactor: centralize ignore constants

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,14 +12,11 @@ import (
 	"github.com/temirov/ctx/internal/utils"
 )
 
-const (
-	ignoreFileName      = ".ignore"
-	gitIgnoreFileName   = ".gitignore"
-	exclusionPrefix     = "EXCL:"
-	gitDirectoryPattern = utils.GitDirectoryName + "/"
-	// showBinaryContentDirective marks patterns whose binary content should be displayed.
-	showBinaryContentDirective = "show-binary-content:"
-)
+// gitDirectoryPattern represents the pattern that matches the Git directory.
+const gitDirectoryPattern = utils.GitDirectoryName + "/"
+
+// showBinaryContentDirective marks patterns whose binary content should be displayed.
+const showBinaryContentDirective = "show-binary-content:"
 
 // LoadIgnoreFilePatterns reads a specified ignore file and returns ignore patterns and binary content patterns.
 //
@@ -69,19 +66,19 @@ func LoadCombinedIgnorePatterns(absoluteDirectoryPath string, exclusionFolder st
 	var combinedPatterns []string
 
 	if useIgnoreFile {
-		ignoreFilePath := filepath.Join(absoluteDirectoryPath, ignoreFileName)
+		ignoreFilePath := filepath.Join(absoluteDirectoryPath, utils.IgnoreFileName)
 		ignoreFilePatterns, _, loadError := LoadIgnoreFilePatterns(ignoreFilePath)
 		if loadError != nil {
-			return nil, fmt.Errorf("loading %s from %s: %w", ignoreFileName, absoluteDirectoryPath, loadError)
+			return nil, fmt.Errorf("loading %s from %s: %w", utils.IgnoreFileName, absoluteDirectoryPath, loadError)
 		}
 		combinedPatterns = append(combinedPatterns, ignoreFilePatterns...)
 	}
 
 	if useGitignore {
-		gitIgnoreFilePath := filepath.Join(absoluteDirectoryPath, gitIgnoreFileName)
+		gitIgnoreFilePath := filepath.Join(absoluteDirectoryPath, utils.GitIgnoreFileName)
 		gitIgnoreFilePatterns, _, loadError := LoadIgnoreFilePatterns(gitIgnoreFilePath)
 		if loadError != nil {
-			return nil, fmt.Errorf("loading %s from %s: %w", gitIgnoreFileName, absoluteDirectoryPath, loadError)
+			return nil, fmt.Errorf("loading %s from %s: %w", utils.GitIgnoreFileName, absoluteDirectoryPath, loadError)
 		}
 		combinedPatterns = append(combinedPatterns, gitIgnoreFilePatterns...)
 	}
@@ -95,7 +92,7 @@ func LoadCombinedIgnorePatterns(absoluteDirectoryPath string, exclusionFolder st
 	trimmedExclusion := strings.TrimSpace(exclusionFolder)
 	if trimmedExclusion != "" {
 		normalizedExclusion := strings.TrimSuffix(trimmedExclusion, "/")
-		exclusionPattern := exclusionPrefix + normalizedExclusion
+		exclusionPattern := utils.ExclusionPrefix + normalizedExclusion
 		isPresent := false
 		for _, pattern := range deduplicatedFilePatterns {
 			if pattern == exclusionPattern {
@@ -136,10 +133,10 @@ func LoadRecursiveIgnorePatterns(rootDirectoryPath string, exclusionFolder strin
 		}
 
 		if useIgnoreFile {
-			ignoreFilePath := filepath.Join(currentDirectoryPath, ignoreFileName)
+			ignoreFilePath := filepath.Join(currentDirectoryPath, utils.IgnoreFileName)
 			ignorePatterns, binaryContentPatterns, loadError := LoadIgnoreFilePatterns(ignoreFilePath)
 			if loadError != nil {
-				return fmt.Errorf("loading %s from %s: %w", ignoreFileName, currentDirectoryPath, loadError)
+				return fmt.Errorf("loading %s from %s: %w", utils.IgnoreFileName, currentDirectoryPath, loadError)
 			}
 			for _, pattern := range ignorePatterns {
 				aggregatedPatterns = append(aggregatedPatterns, prefix+pattern)
@@ -150,10 +147,10 @@ func LoadRecursiveIgnorePatterns(rootDirectoryPath string, exclusionFolder strin
 		}
 
 		if useGitignore {
-			gitIgnoreFilePath := filepath.Join(currentDirectoryPath, gitIgnoreFileName)
+			gitIgnoreFilePath := filepath.Join(currentDirectoryPath, utils.GitIgnoreFileName)
 			gitIgnorePatterns, _, loadError := LoadIgnoreFilePatterns(gitIgnoreFilePath)
 			if loadError != nil {
-				return fmt.Errorf("loading %s from %s: %w", gitIgnoreFileName, currentDirectoryPath, loadError)
+				return fmt.Errorf("loading %s from %s: %w", utils.GitIgnoreFileName, currentDirectoryPath, loadError)
 			}
 			for _, pattern := range gitIgnorePatterns {
 				aggregatedPatterns = append(aggregatedPatterns, prefix+pattern)
@@ -177,7 +174,7 @@ func LoadRecursiveIgnorePatterns(rootDirectoryPath string, exclusionFolder strin
 	trimmedExclusion := strings.TrimSpace(exclusionFolder)
 	if trimmedExclusion != "" {
 		normalizedExclusion := strings.TrimSuffix(trimmedExclusion, "/")
-		exclusionPattern := exclusionPrefix + normalizedExclusion
+		exclusionPattern := utils.ExclusionPrefix + normalizedExclusion
 		isPresent := false
 		for _, pattern := range deduplicatedPatterns {
 			if pattern == exclusionPattern {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+
+	"github.com/temirov/ctx/internal/utils"
 )
 
 // writeTestFile creates a file with the specified content, failing the test on error.
@@ -25,13 +27,13 @@ func TestLoadRecursiveIgnorePatternsNestedIgnore(testingHandle *testing.T) {
 	)
 
 	rootDirectory := testingHandle.TempDir()
-	writeTestFile(testingHandle, filepath.Join(rootDirectory, ignoreFileName), rootPatternName+"\n")
+	writeTestFile(testingHandle, filepath.Join(rootDirectory, utils.IgnoreFileName), rootPatternName+"\n")
 
 	nestedDirectoryPath := filepath.Join(rootDirectory, nestedDirName)
 	if makeDirErr := os.MkdirAll(nestedDirectoryPath, 0o755); makeDirErr != nil {
 		testingHandle.Fatalf("failed to create nested directory: %v", makeDirErr)
 	}
-	writeTestFile(testingHandle, filepath.Join(nestedDirectoryPath, ignoreFileName), nestedPatternName+"\n")
+	writeTestFile(testingHandle, filepath.Join(nestedDirectoryPath, utils.IgnoreFileName), nestedPatternName+"\n")
 
 	patternList, binaryPatternList, loadError := LoadRecursiveIgnorePatterns(rootDirectory, "", false, true, false)
 	if loadError != nil {
@@ -58,13 +60,13 @@ func TestLoadRecursiveIgnorePatternsNestedGitIgnore(testingHandle *testing.T) {
 	)
 
 	rootDirectory := testingHandle.TempDir()
-	writeTestFile(testingHandle, filepath.Join(rootDirectory, gitIgnoreFileName), rootGitPattern+"\n")
+	writeTestFile(testingHandle, filepath.Join(rootDirectory, utils.GitIgnoreFileName), rootGitPattern+"\n")
 
 	nestedDirectoryPath := filepath.Join(rootDirectory, nestedGitDir)
 	if makeDirErr := os.MkdirAll(nestedDirectoryPath, 0o755); makeDirErr != nil {
 		testingHandle.Fatalf("failed to create nested directory: %v", makeDirErr)
 	}
-	writeTestFile(testingHandle, filepath.Join(nestedDirectoryPath, gitIgnoreFileName), nestedGitPattern+"\n")
+	writeTestFile(testingHandle, filepath.Join(nestedDirectoryPath, utils.GitIgnoreFileName), nestedGitPattern+"\n")
 
 	patternList, binaryPatternList, loadError := LoadRecursiveIgnorePatterns(rootDirectory, "", true, false, false)
 	if loadError != nil {
@@ -90,13 +92,13 @@ func TestLoadRecursiveIgnorePatternsBinaryContent(testingHandle *testing.T) {
 	)
 
 	rootDirectory := testingHandle.TempDir()
-	writeTestFile(testingHandle, filepath.Join(rootDirectory, ignoreFileName), showBinaryContentDirective+binaryPatternName+"\n")
+	writeTestFile(testingHandle, filepath.Join(rootDirectory, utils.IgnoreFileName), showBinaryContentDirective+binaryPatternName+"\n")
 
 	nestedDirectoryPath := filepath.Join(rootDirectory, nestedDirectoryName)
 	if makeDirError := os.MkdirAll(nestedDirectoryPath, 0o755); makeDirError != nil {
 		testingHandle.Fatalf("failed to create nested directory: %v", makeDirError)
 	}
-	writeTestFile(testingHandle, filepath.Join(nestedDirectoryPath, ignoreFileName), showBinaryContentDirective+binaryPatternName+"\n")
+	writeTestFile(testingHandle, filepath.Join(nestedDirectoryPath, utils.IgnoreFileName), showBinaryContentDirective+binaryPatternName+"\n")
 
 	patternList, binaryPatternList, loadError := LoadRecursiveIgnorePatterns(rootDirectory, "", false, true, false)
 	if loadError != nil {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -7,12 +7,16 @@ import (
 	"strings"
 )
 
-// Constants related to ignore file handling.
+// Ignore file constants used across the project.
 const (
-	IgnoreFileName    = ".ignore"
+	// IgnoreFileName is the name of the project's ignore file.
+	IgnoreFileName = ".ignore"
+	// GitIgnoreFileName is the name of the Git ignore file.
 	GitIgnoreFileName = ".gitignore"
-	ExclusionPrefix   = "EXCL:"
-	GitDirectoryName  = ".git"
+	// ExclusionPrefix marks patterns that exclude directories from processing.
+	ExclusionPrefix = "EXCL:"
+	// GitDirectoryName is the name of the Git repository directory.
+	GitDirectoryName = ".git"
 )
 
 var serviceFiles = map[string]struct{}{


### PR DESCRIPTION
## Summary
- centralize ignore-related constants in internal/utils
- reference shared constants from config package
- update config tests to rely on utils constants

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ba0e70b44c83278d82c49fab852fcf