### PR TITLE
test: consolidate LoadRecursiveIgnorePatterns tests

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,4 +1,4 @@
-package config
+package config_test
 
 import (
 	"os"
@@ -7,7 +7,13 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/temirov/ctx/internal/config"
 	"github.com/temirov/ctx/internal/utils"
+)
+
+const (
+	gitDirectoryPattern        = utils.GitDirectoryName + "/"
+	showBinaryContentDirective = "show-binary-content:"
 )
 
 // writeTestFile creates a file with the specified content, failing the test on error.
@@ -18,101 +24,98 @@ func writeTestFile(testingHandle *testing.T, filePath string, content string) {
 	}
 }
 
-// TestLoadRecursiveIgnorePatternsNestedIgnore verifies that ignore patterns from nested .ignore files are aggregated with prefixed paths.
-func TestLoadRecursiveIgnorePatternsNestedIgnore(testingHandle *testing.T) {
+// TestLoadRecursiveIgnorePatterns verifies that ignore and binary content patterns are correctly aggregated across nested directories.
+func TestLoadRecursiveIgnorePatterns(testingHandle *testing.T) {
 	const (
-		rootPatternName   = "root.txt"
-		nestedPatternName = "nested.txt"
-		nestedDirName     = "nested"
-	)
+		nestedIgnoreSubtestName    = "nested ignore files"
+		nestedGitignoreSubtestName = "nested gitignore files"
+		binaryContentSubtestName   = "binary content patterns"
 
-	rootDirectory := testingHandle.TempDir()
-	writeTestFile(testingHandle, filepath.Join(rootDirectory, utils.IgnoreFileName), rootPatternName+"\n")
+		rootIgnorePatternName   = "root.txt"
+		nestedIgnorePatternName = "nested.txt"
+		nestedIgnoreDirName     = "nested"
 
-	nestedDirectoryPath := filepath.Join(rootDirectory, nestedDirName)
-	if makeDirErr := os.MkdirAll(nestedDirectoryPath, 0o755); makeDirErr != nil {
-		testingHandle.Fatalf("failed to create nested directory: %v", makeDirErr)
-	}
-	writeTestFile(testingHandle, filepath.Join(nestedDirectoryPath, utils.IgnoreFileName), nestedPatternName+"\n")
+		rootGitPatternName   = "root.md"
+		nestedGitPatternName = "nested.md"
+		nestedGitDirName     = "deep"
 
-	patternList, binaryPatternList, loadError := LoadRecursiveIgnorePatterns(rootDirectory, "", false, true, false)
-	if loadError != nil {
-		testingHandle.Fatalf("LoadRecursiveIgnorePatterns failed: %v", loadError)
-	}
-
-	sort.Strings(patternList)
-	expectedPatterns := []string{rootPatternName, nestedDirName + "/" + nestedPatternName, gitDirectoryPattern}
-	sort.Strings(expectedPatterns)
-	if !reflect.DeepEqual(patternList, expectedPatterns) {
-		testingHandle.Fatalf("unexpected patterns: got %v want %v", patternList, expectedPatterns)
-	}
-	if len(binaryPatternList) != 0 {
-		testingHandle.Fatalf("expected no binary content patterns, got %v", binaryPatternList)
-	}
-}
-
-// TestLoadRecursiveIgnorePatternsNestedGitIgnore verifies that ignore patterns from nested .gitignore files are aggregated with prefixed paths.
-func TestLoadRecursiveIgnorePatternsNestedGitIgnore(testingHandle *testing.T) {
-	const (
-		rootGitPattern   = "root.md"
-		nestedGitPattern = "nested.md"
-		nestedGitDir     = "deep"
-	)
-
-	rootDirectory := testingHandle.TempDir()
-	writeTestFile(testingHandle, filepath.Join(rootDirectory, utils.GitIgnoreFileName), rootGitPattern+"\n")
-
-	nestedDirectoryPath := filepath.Join(rootDirectory, nestedGitDir)
-	if makeDirErr := os.MkdirAll(nestedDirectoryPath, 0o755); makeDirErr != nil {
-		testingHandle.Fatalf("failed to create nested directory: %v", makeDirErr)
-	}
-	writeTestFile(testingHandle, filepath.Join(nestedDirectoryPath, utils.GitIgnoreFileName), nestedGitPattern+"\n")
-
-	patternList, binaryPatternList, loadError := LoadRecursiveIgnorePatterns(rootDirectory, "", true, false, false)
-	if loadError != nil {
-		testingHandle.Fatalf("LoadRecursiveIgnorePatterns failed: %v", loadError)
-	}
-
-	sort.Strings(patternList)
-	expectedPatterns := []string{rootGitPattern, nestedGitDir + "/" + nestedGitPattern, gitDirectoryPattern}
-	sort.Strings(expectedPatterns)
-	if !reflect.DeepEqual(patternList, expectedPatterns) {
-		testingHandle.Fatalf("unexpected patterns: got %v want %v", patternList, expectedPatterns)
-	}
-	if len(binaryPatternList) != 0 {
-		testingHandle.Fatalf("expected no binary content patterns, got %v", binaryPatternList)
-	}
-}
-
-// TestLoadRecursiveIgnorePatternsBinaryContent verifies aggregation of binary content patterns.
-func TestLoadRecursiveIgnorePatternsBinaryContent(testingHandle *testing.T) {
-	const (
 		binaryPatternName   = "data.bin"
-		nestedDirectoryName = "nested"
+		nestedBinaryDirName = "binary"
 	)
 
-	rootDirectory := testingHandle.TempDir()
-	writeTestFile(testingHandle, filepath.Join(rootDirectory, utils.IgnoreFileName), showBinaryContentDirective+binaryPatternName+"\n")
-
-	nestedDirectoryPath := filepath.Join(rootDirectory, nestedDirectoryName)
-	if makeDirError := os.MkdirAll(nestedDirectoryPath, 0o755); makeDirError != nil {
-		testingHandle.Fatalf("failed to create nested directory: %v", makeDirError)
+	testCases := []struct {
+		name                   string
+		useGitignore           bool
+		useIgnoreFile          bool
+		createTestFiles        func(*testing.T, string)
+		expectedPatterns       []string
+		expectedBinaryPatterns []string
+	}{
+		{
+			name:          nestedIgnoreSubtestName,
+			useIgnoreFile: true,
+			createTestFiles: func(testingHandle *testing.T, rootDirectory string) {
+				writeTestFile(testingHandle, filepath.Join(rootDirectory, utils.IgnoreFileName), rootIgnorePatternName+"\n")
+				nestedDirectoryPath := filepath.Join(rootDirectory, nestedIgnoreDirName)
+				if makeDirError := os.MkdirAll(nestedDirectoryPath, 0o755); makeDirError != nil {
+					testingHandle.Fatalf("failed to create nested directory: %v", makeDirError)
+				}
+				writeTestFile(testingHandle, filepath.Join(nestedDirectoryPath, utils.IgnoreFileName), nestedIgnorePatternName+"\n")
+			},
+			expectedPatterns:       []string{rootIgnorePatternName, nestedIgnoreDirName + "/" + nestedIgnorePatternName, gitDirectoryPattern},
+			expectedBinaryPatterns: []string{},
+		},
+		{
+			name:         nestedGitignoreSubtestName,
+			useGitignore: true,
+			createTestFiles: func(testingHandle *testing.T, rootDirectory string) {
+				writeTestFile(testingHandle, filepath.Join(rootDirectory, utils.GitIgnoreFileName), rootGitPatternName+"\n")
+				nestedDirectoryPath := filepath.Join(rootDirectory, nestedGitDirName)
+				if makeDirError := os.MkdirAll(nestedDirectoryPath, 0o755); makeDirError != nil {
+					testingHandle.Fatalf("failed to create nested directory: %v", makeDirError)
+				}
+				writeTestFile(testingHandle, filepath.Join(nestedDirectoryPath, utils.GitIgnoreFileName), nestedGitPatternName+"\n")
+			},
+			expectedPatterns:       []string{rootGitPatternName, nestedGitDirName + "/" + nestedGitPatternName, gitDirectoryPattern},
+			expectedBinaryPatterns: []string{},
+		},
+		{
+			name:          binaryContentSubtestName,
+			useIgnoreFile: true,
+			createTestFiles: func(testingHandle *testing.T, rootDirectory string) {
+				writeTestFile(testingHandle, filepath.Join(rootDirectory, utils.IgnoreFileName), showBinaryContentDirective+binaryPatternName+"\n")
+				nestedDirectoryPath := filepath.Join(rootDirectory, nestedBinaryDirName)
+				if makeDirError := os.MkdirAll(nestedDirectoryPath, 0o755); makeDirError != nil {
+					testingHandle.Fatalf("failed to create nested directory: %v", makeDirError)
+				}
+				writeTestFile(testingHandle, filepath.Join(nestedDirectoryPath, utils.IgnoreFileName), showBinaryContentDirective+binaryPatternName+"\n")
+			},
+			expectedPatterns:       []string{gitDirectoryPattern},
+			expectedBinaryPatterns: []string{binaryPatternName, nestedBinaryDirName + "/" + binaryPatternName},
+		},
 	}
-	writeTestFile(testingHandle, filepath.Join(nestedDirectoryPath, utils.IgnoreFileName), showBinaryContentDirective+binaryPatternName+"\n")
 
-	patternList, binaryPatternList, loadError := LoadRecursiveIgnorePatterns(rootDirectory, "", false, true, false)
-	if loadError != nil {
-		testingHandle.Fatalf("LoadRecursiveIgnorePatterns failed: %v", loadError)
-	}
+	for _, testCase := range testCases {
+		testingHandle.Run(testCase.name, func(testingHandle *testing.T) {
+			rootDirectory := testingHandle.TempDir()
+			testCase.createTestFiles(testingHandle, rootDirectory)
 
-	if len(patternList) != 1 || patternList[0] != gitDirectoryPattern {
-		testingHandle.Fatalf("unexpected ignore patterns: %v", patternList)
-	}
+			patternList, binaryPatternList, loadError := config.LoadRecursiveIgnorePatterns(rootDirectory, "", testCase.useGitignore, testCase.useIgnoreFile, false)
+			if loadError != nil {
+				testingHandle.Fatalf("LoadRecursiveIgnorePatterns failed: %v", loadError)
+			}
 
-	sort.Strings(binaryPatternList)
-	expectedBinaryPatterns := []string{binaryPatternName, nestedDirectoryName + "/" + binaryPatternName}
-	sort.Strings(expectedBinaryPatterns)
-	if !reflect.DeepEqual(binaryPatternList, expectedBinaryPatterns) {
-		testingHandle.Fatalf("unexpected binary content patterns: got %v want %v", binaryPatternList, expectedBinaryPatterns)
+			sort.Strings(patternList)
+			sort.Strings(testCase.expectedPatterns)
+			if !reflect.DeepEqual(patternList, testCase.expectedPatterns) {
+				testingHandle.Fatalf("unexpected patterns: got %v want %v", patternList, testCase.expectedPatterns)
+			}
+
+			sort.Strings(binaryPatternList)
+			sort.Strings(testCase.expectedBinaryPatterns)
+			if !reflect.DeepEqual(binaryPatternList, testCase.expectedBinaryPatterns) {
+				testingHandle.Fatalf("unexpected binary content patterns: got %v want %v", binaryPatternList, testCase.expectedBinaryPatterns)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- convert config tests to a table-driven format and rename package to config_test

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ba123796fc83279b97fc085be8f0f2