### PR TITLE
Clarify variable names in docs collector and binary utils

### DIFF
--- a/internal/utils/binary.go
+++ b/internal/utils/binary.go
@@ -27,16 +27,16 @@ func IsBinary(data []byte) bool {
 // IsFileBinary reads up to sniffLen bytes from the file at path and determines
 // if the content appears to be binary.
 func IsFileBinary(path string) bool {
-	f, err := os.Open(path)
+	fileHandle, err := os.Open(path)
 	if err != nil {
 		return false
 	}
-	defer f.Close()
+	defer fileHandle.Close()
 
-	buf := make([]byte, sniffLen)
-	n, err := f.Read(buf)
+	buffer := make([]byte, sniffLen)
+	bytesRead, err := fileHandle.Read(buffer)
 	if err != nil && err != io.EOF {
 		return false
 	}
-	return IsBinary(buf[:n])
+	return IsBinary(buffer[:bytesRead])
 }


### PR DESCRIPTION
## Summary
- rename Collector receiver to `collector` and expand short variables for clearer documentation collection
- rename file processing variables for explicit binary checks

## Testing
- `go fmt internal/docs/collector.go`
- `go fmt internal/utils/binary.go`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ba14079dc48327a946181b60915609