### PR TITLE
Remove unused XML element constants

### DIFF
--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -11,25 +11,24 @@ import (
 )
 
 const (
-	indentPrefix          = ""
-	indentSpacer          = "  "
+	indentPrefix = ""
+	indentSpacer = "  "
+
 	separatorLine         = "----------------------------------------"
 	documentationHeader   = "--- Documentation ---"
 	callchainMetaHeader   = "----- CALLCHAIN METADATA -----"
 	callchainFunctionsHdr = "----- FUNCTIONS -----"
 	callchainDocsHeader   = "--- DOCS ---"
-	xmlHeader             = xml.Header
-	xmlRootElement        = "result"
-	xmlDocumentationName  = "documentation"
-	xmlCodeName           = "code"
-	xmlEntryName          = "entry"
-	xmlItemName           = "item"
-	xmlCallchainsName     = "callchains"
-	xmlCallchainName      = "callchain"
-	binaryContentOmitted  = "(binary content omitted)"
-	mimeTypeLabel         = "Mime Type: "
-	binaryNodeFormat      = "[Binary] %s (%s%s)\n"
-	binaryTreeFormat      = "%s[Binary] %s (%s%s)\n"
+
+	xmlHeader         = xml.Header
+	xmlRootElement    = "result"
+	xmlCallchainsName = "callchains"
+	xmlCallchainName  = "callchain"
+
+	binaryContentOmitted = "(binary content omitted)"
+	mimeTypeLabel        = "Mime Type: "
+	binaryNodeFormat     = "[Binary] %s (%s%s)\n"
+	binaryTreeFormat     = "%s[Binary] %s (%s%s)\n"
 )
 
 // RenderCallChainRaw returns the call‑chain output in raw text format.


### PR DESCRIPTION
## Summary
- drop unused XML element constants
- organize remaining constants into logical groups

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ba1635c7e48327a3305b21eb955260