### PR TITLE
refactor: remove binary pattern argument from tree functions

### DIFF
--- a/cmd/ctx/main.go
+++ b/cmd/ctx/main.go
@@ -308,7 +308,7 @@ func runTreeOrContentCommand(
 				continue
 			}
 			if commandName == types.CommandTree {
-				nodes, dataError := commands.GetTreeData(info.AbsolutePath, ignorePatternList, binaryContentPatternList)
+				nodes, dataError := commands.GetTreeData(info.AbsolutePath, ignorePatternList)
 				if dataError == nil && len(nodes) > 0 {
 					collected = append(collected, nodes[0])
 				}

--- a/internal/commands/tree.go
+++ b/internal/commands/tree.go
@@ -13,8 +13,7 @@ import (
 // GetTreeData generates the tree structure data for a given directory.
 // It returns a slice containing a single root node representing the directory.
 // Warnings for skipped subdirectories are printed to stderr.
-func GetTreeData(rootDirectoryPath string, ignorePatterns []string, binaryContentPatterns []string) ([]*types.TreeOutputNode, error) {
-	_ = binaryContentPatterns
+func GetTreeData(rootDirectoryPath string, ignorePatterns []string) ([]*types.TreeOutputNode, error) {
 	absoluteRootDirPath, absolutePathError := filepath.Abs(rootDirectoryPath)
 	if absolutePathError != nil {
 		return nil, fmt.Errorf("getting absolute path for %s: %w", rootDirectoryPath, absolutePathError)
@@ -26,7 +25,7 @@ func GetTreeData(rootDirectoryPath string, ignorePatterns []string, binaryConten
 		Type: types.NodeTypeDirectory,
 	}
 
-	children, buildError := buildTreeNodes(absoluteRootDirPath, absoluteRootDirPath, ignorePatterns, binaryContentPatterns)
+	children, buildError := buildTreeNodes(absoluteRootDirPath, absoluteRootDirPath, ignorePatterns)
 	if buildError != nil {
 		return nil, fmt.Errorf("building tree for %s: %w", rootDirectoryPath, buildError)
 	}
@@ -36,8 +35,7 @@ func GetTreeData(rootDirectoryPath string, ignorePatterns []string, binaryConten
 }
 
 // buildTreeNodes recursively builds child nodes for the directory tree.
-func buildTreeNodes(currentDirectoryPath string, rootDirectoryPath string, ignorePatterns []string, binaryContentPatterns []string) ([]*types.TreeOutputNode, error) {
-	_ = binaryContentPatterns
+func buildTreeNodes(currentDirectoryPath string, rootDirectoryPath string, ignorePatterns []string) ([]*types.TreeOutputNode, error) {
 	var nodes []*types.TreeOutputNode
 
 	directoryEntries, readDirectoryError := os.ReadDir(currentDirectoryPath)
@@ -59,7 +57,7 @@ func buildTreeNodes(currentDirectoryPath string, rootDirectoryPath string, ignor
 
 		if directoryEntry.IsDir() {
 			node.Type = types.NodeTypeDirectory
-			childNodes, buildError := buildTreeNodes(childPath, rootDirectoryPath, ignorePatterns, binaryContentPatterns)
+			childNodes, buildError := buildTreeNodes(childPath, rootDirectoryPath, ignorePatterns)
 			if buildError != nil {
 				fmt.Fprintf(os.Stderr, "Warning: Skipping subdirectory %s due to error: %v\n", childPath, buildError)
 				node.Children = nil


### PR DESCRIPTION
## Summary
- simplify GetTreeData and buildTreeNodes signatures by dropping unused binaryContentPatterns parameter
- update CLI call site to match new tree API

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ba19980bac8327926eb472c203a0ca