### PR TITLE
Add tests for utilities, output rendering, and command behavior

### DIFF
--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -1,0 +1,128 @@
+package commands_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/temirov/ctx/internal/commands"
+	"github.com/temirov/ctx/internal/types"
+)
+
+const (
+	textFileName      = "plain.txt"
+	textFileContent   = "hello"
+	binaryFileName    = "data.bin"
+	binaryFileContent = "\x00\xff"
+	ignoredFileName   = "ignored.txt"
+	directoryName     = "dir"
+	ignoredDirName    = "skip"
+)
+
+// TestGetContentData verifies file data collection respecting ignore patterns and binary detection.
+func TestGetContentData(testingHandle *testing.T) {
+	rootDirectory := testingHandle.TempDir()
+	textFilePath := filepath.Join(rootDirectory, textFileName)
+	binaryFilePath := filepath.Join(rootDirectory, binaryFileName)
+	ignoredFilePath := filepath.Join(rootDirectory, ignoredFileName)
+	writeError := os.WriteFile(textFilePath, []byte(textFileContent), 0o644)
+	if writeError != nil {
+		testingHandle.Fatalf("writing text file: %v", writeError)
+	}
+	writeError = os.WriteFile(binaryFilePath, []byte(binaryFileContent), 0o644)
+	if writeError != nil {
+		testingHandle.Fatalf("writing binary file: %v", writeError)
+	}
+	writeError = os.WriteFile(ignoredFilePath, []byte("x"), 0o644)
+	if writeError != nil {
+		testingHandle.Fatalf("writing ignored file: %v", writeError)
+	}
+	fileOutputs, getError := commands.GetContentData(rootDirectory, []string{ignoredFileName}, nil)
+	if getError != nil {
+		testingHandle.Fatalf("GetContentData error: %v", getError)
+	}
+	if len(fileOutputs) != 2 {
+		testingHandle.Fatalf("expected 2 files, got %d", len(fileOutputs))
+	}
+	foundText := false
+	foundBinary := false
+	for _, fileOutput := range fileOutputs {
+		baseName := filepath.Base(fileOutput.Path)
+		if baseName == textFileName {
+			if fileOutput.Type != types.NodeTypeFile || fileOutput.Content != textFileContent {
+				testingHandle.Fatalf("unexpected text file output: %+v", fileOutput)
+			}
+			foundText = true
+		} else if baseName == binaryFileName {
+			if fileOutput.Type != types.NodeTypeBinary || fileOutput.Content != "" || fileOutput.MimeType == "" {
+				testingHandle.Fatalf("unexpected binary file output: %+v", fileOutput)
+			}
+			foundBinary = true
+		} else {
+			testingHandle.Fatalf("unexpected file: %s", baseName)
+		}
+	}
+	if !foundText || !foundBinary {
+		testingHandle.Fatalf("missing expected files")
+	}
+}
+
+// TestGetTreeData verifies directory tree generation and ignore handling.
+func TestGetTreeData(testingHandle *testing.T) {
+	rootDirectory := testingHandle.TempDir()
+	directoryPath := filepath.Join(rootDirectory, directoryName)
+	ignoredDirectoryPath := filepath.Join(rootDirectory, ignoredDirName)
+	makeDirError := os.MkdirAll(directoryPath, 0o755)
+	if makeDirError != nil {
+		testingHandle.Fatalf("mkdir: %v", makeDirError)
+	}
+	makeDirError = os.MkdirAll(ignoredDirectoryPath, 0o755)
+	if makeDirError != nil {
+		testingHandle.Fatalf("mkdir ignored: %v", makeDirError)
+	}
+	textFilePath := filepath.Join(directoryPath, textFileName)
+	binaryFilePath := filepath.Join(rootDirectory, binaryFileName)
+	writeError := os.WriteFile(textFilePath, []byte(textFileContent), 0o644)
+	if writeError != nil {
+		testingHandle.Fatalf("write text: %v", writeError)
+	}
+	writeError = os.WriteFile(binaryFilePath, []byte(binaryFileContent), 0o644)
+	if writeError != nil {
+		testingHandle.Fatalf("write binary: %v", writeError)
+	}
+	tree, treeError := commands.GetTreeData(rootDirectory, []string{ignoredDirName + "/"})
+	if treeError != nil {
+		testingHandle.Fatalf("GetTreeData error: %v", treeError)
+	}
+	if len(tree) != 1 {
+		testingHandle.Fatalf("expected 1 root node, got %d", len(tree))
+	}
+	rootNode := tree[0]
+	if len(rootNode.Children) != 2 {
+		testingHandle.Fatalf("expected 2 children, got %d", len(rootNode.Children))
+	}
+	foundDir := false
+	foundBinary := false
+	for _, child := range rootNode.Children {
+		baseName := filepath.Base(child.Path)
+		if baseName == directoryName {
+			if child.Type != types.NodeTypeDirectory || len(child.Children) != 1 {
+				testingHandle.Fatalf("unexpected directory node: %+v", child)
+			}
+			if filepath.Base(child.Children[0].Path) != textFileName {
+				testingHandle.Fatalf("missing text file in directory")
+			}
+			foundDir = true
+		} else if baseName == binaryFileName {
+			if child.Type != types.NodeTypeBinary {
+				testingHandle.Fatalf("expected binary node, got %s", child.Type)
+			}
+			foundBinary = true
+		} else {
+			testingHandle.Fatalf("unexpected child: %s", baseName)
+		}
+	}
+	if !foundDir || !foundBinary {
+		testingHandle.Fatalf("missing expected nodes")
+	}
+}

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -1,0 +1,135 @@
+package output_test
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/temirov/ctx/internal/output"
+	"github.com/temirov/ctx/internal/types"
+)
+
+const (
+	callChainTarget       = "alpha"
+	callChainCaller       = "beta"
+	callChainCallee       = "gamma"
+	callChainFunctionBody = "body"
+	documentationKind     = "func"
+	documentationName     = "alpha"
+	documentationDoc      = "doc"
+	filePath              = "file.txt"
+	fileContent           = "content"
+	jsonExpected          = "{\n  \"documentation\": [\n    {\n      \"type\": \"var\",\n      \"name\": \"x\",\n      \"documentation\": \"d\"\n    }\n  ],\n  \"code\": [\n    {\n      \"path\": \"file.txt\",\n      \"type\": \"file\",\n      \"content\": \"content\"\n    }\n  ]\n}"
+	xmlExpected           = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<result>\n  <documentation>\n    <entry>\n      <type>var</type>\n      <name>x</name>\n      <documentation>d</documentation>\n    </entry>\n  </documentation>\n  <code>\n    <item>\n      <path>file.txt</path>\n      <type>file</type>\n      <content>content</content>\n      <documentation></documentation>\n    </item>\n  </code>\n</result>"
+	rawExpected           = "--- Documentation ---\nfunc alpha\ndoc\n\nFile: file.txt\ncontent\nEnd of file: file.txt\n----------------------------------------\n"
+)
+
+// TestRenderCallChainRaw verifies raw callchain rendering.
+func TestRenderCallChainRaw(testingHandle *testing.T) {
+	callees := []string{callChainCallee}
+	callChain := &types.CallChainOutput{
+		TargetFunction: callChainTarget,
+		Callers:        []string{callChainCaller},
+		Callees:        &callees,
+		Functions: map[string]string{
+			callChainTarget: callChainFunctionBody,
+			callChainCaller: callChainFunctionBody,
+			callChainCallee: callChainFunctionBody,
+		},
+		Documentation: []types.DocumentationEntry{
+			{Kind: documentationKind, Name: documentationName, Doc: documentationDoc},
+		},
+	}
+	rendered := output.RenderCallChainRaw(callChain)
+	expected := "----- CALLCHAIN METADATA -----\n" +
+		"Target Function: " + callChainTarget + "\n" +
+		"Callers:\n " + callChainCaller + "\n" +
+		"Callees:\n " + callChainCallee + "\n\n" +
+		"----- FUNCTIONS -----\n" +
+		"Function: " + callChainTarget + "\n" +
+		"----------------------------------------\n" + callChainFunctionBody + "\n" +
+		"----------------------------------------\n\n" +
+		"Function: " + callChainCaller + "\n" +
+		"----------------------------------------\n" + callChainFunctionBody + "\n" +
+		"----------------------------------------\n\n" +
+		"Function: " + callChainCallee + "\n" +
+		"----------------------------------------\n" + callChainFunctionBody + "\n" +
+		"----------------------------------------\n\n" +
+		"--- DOCS ---\n" +
+		documentationKind + " " + documentationName + "\n" +
+		documentationDoc + "\n\n"
+	if rendered != expected {
+		testingHandle.Fatalf("unexpected output: %q", rendered)
+	}
+}
+
+// TestRenderJSON verifies JSON rendering and deduplication.
+func TestRenderJSON(testingHandle *testing.T) {
+	documentationEntries := []types.DocumentationEntry{
+		{Kind: "var", Name: "x", Doc: "d"},
+		{Kind: "var", Name: "x", Doc: "d"},
+	}
+	items := []interface{}{
+		&types.FileOutput{Path: filePath, Type: types.NodeTypeFile, Content: fileContent},
+		&types.FileOutput{Path: filePath, Type: types.NodeTypeFile, Content: fileContent},
+	}
+	rendered, renderError := output.RenderJSON(documentationEntries, items)
+	if renderError != nil {
+		testingHandle.Fatalf("RenderJSON error: %v", renderError)
+	}
+	if rendered != jsonExpected {
+		testingHandle.Fatalf("unexpected JSON: %s", rendered)
+	}
+}
+
+// TestRenderXML verifies XML rendering and deduplication.
+func TestRenderXML(testingHandle *testing.T) {
+	documentationEntries := []types.DocumentationEntry{
+		{Kind: "var", Name: "x", Doc: "d"},
+		{Kind: "var", Name: "x", Doc: "d"},
+	}
+	items := []interface{}{
+		&types.FileOutput{Path: filePath, Type: types.NodeTypeFile, Content: fileContent},
+		&types.FileOutput{Path: filePath, Type: types.NodeTypeFile, Content: fileContent},
+	}
+	rendered, renderError := output.RenderXML(documentationEntries, items)
+	if renderError != nil {
+		testingHandle.Fatalf("RenderXML error: %v", renderError)
+	}
+	if rendered != xmlExpected {
+		testingHandle.Fatalf("unexpected XML: %s", rendered)
+	}
+}
+
+// TestRenderRaw verifies raw output rendering.
+func TestRenderRaw(testingHandle *testing.T) {
+	documentationEntries := []types.DocumentationEntry{
+		{Kind: documentationKind, Name: documentationName, Doc: documentationDoc},
+		{Kind: documentationKind, Name: documentationName, Doc: documentationDoc},
+	}
+	items := []interface{}{
+		&types.FileOutput{Path: filePath, Type: types.NodeTypeFile, Content: fileContent},
+		&types.FileOutput{Path: filePath, Type: types.NodeTypeFile, Content: fileContent},
+	}
+	originalStdout := os.Stdout
+	readPipe, writePipe, pipeError := os.Pipe()
+	if pipeError != nil {
+		testingHandle.Fatalf("pipe error: %v", pipeError)
+	}
+	os.Stdout = writePipe
+	renderError := output.RenderRaw(types.CommandContent, documentationEntries, items)
+	writePipe.Close()
+	os.Stdout = originalStdout
+	if renderError != nil {
+		testingHandle.Fatalf("RenderRaw error: %v", renderError)
+	}
+	captured, readError := io.ReadAll(readPipe)
+	if readError != nil {
+		testingHandle.Fatalf("read error: %v", readError)
+	}
+	trimmed := strings.ReplaceAll(string(captured), "\r", "")
+	if trimmed != rawExpected {
+		testingHandle.Fatalf("unexpected raw output: %q", trimmed)
+	}
+}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -1,0 +1,131 @@
+package utils_test
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/temirov/ctx/internal/utils"
+)
+
+const (
+	textFileName      = "plain.txt"
+	binaryFileName    = "data.bin"
+	ignoredFileName   = "ignored.txt"
+	textFileContent   = "hello world"
+	binaryFileContent = "\x00\xff\x00\xff"
+	filePatternIgnore = ignoredFileName
+	filePatternBinary = binaryFileName
+	directoryPattern  = "dir/"
+	exclusionPattern  = utils.ExclusionPrefix + "node"
+	binaryPattern     = "bin/"
+)
+
+// TestIsBinary verifies binary data detection for byte slices.
+func TestIsBinary(testingHandle *testing.T) {
+	const (
+		asciiData    = "hello"
+		nullByteData = "hi\x00"
+		invalidUTF8  = "\xff\xfe"
+	)
+	testCases := []struct {
+		name           string
+		data           []byte
+		expectedBinary bool
+	}{
+		{name: "empty", data: []byte{}, expectedBinary: false},
+		{name: "ascii", data: []byte(asciiData), expectedBinary: false},
+		{name: "null byte", data: []byte(nullByteData), expectedBinary: true},
+		{name: "invalid utf8", data: []byte(invalidUTF8), expectedBinary: true},
+	}
+	for _, testCase := range testCases {
+		testingHandle.Run(testCase.name, func(testingHandle *testing.T) {
+			isBinary := utils.IsBinary(testCase.data)
+			if isBinary != testCase.expectedBinary {
+				testingHandle.Fatalf("IsBinary(%v) = %v, want %v", testCase.data, isBinary, testCase.expectedBinary)
+			}
+		})
+	}
+}
+
+// TestIsFileBinary verifies binary file detection.
+func TestIsFileBinary(testingHandle *testing.T) {
+	rootDirectory := testingHandle.TempDir()
+	testCases := []struct {
+		name           string
+		fileName       string
+		content        []byte
+		expectedBinary bool
+	}{
+		{name: "text file", fileName: textFileName, content: []byte(textFileContent), expectedBinary: false},
+		{name: "binary file", fileName: binaryFileName, content: []byte(binaryFileContent), expectedBinary: true},
+	}
+	for _, testCase := range testCases {
+		testingHandle.Run(testCase.name, func(testingHandle *testing.T) {
+			filePath := filepath.Join(rootDirectory, testCase.fileName)
+			writeError := os.WriteFile(filePath, testCase.content, 0o644)
+			if writeError != nil {
+				testingHandle.Fatalf("writing test file: %v", writeError)
+			}
+			isBinary := utils.IsFileBinary(filePath)
+			if isBinary != testCase.expectedBinary {
+				testingHandle.Fatalf("IsFileBinary(%s) = %v, want %v", filePath, isBinary, testCase.expectedBinary)
+			}
+		})
+	}
+}
+
+// TestShouldIgnoreByPath verifies path-based ignore matching.
+func TestShouldIgnoreByPath(testingHandle *testing.T) {
+	testCases := []struct {
+		name            string
+		path            string
+		patterns        []string
+		expectedIgnored bool
+	}{
+		{name: "service file", path: utils.IgnoreFileName, patterns: nil, expectedIgnored: true},
+		{name: "file pattern", path: ignoredFileName, patterns: []string{filePatternIgnore}, expectedIgnored: true},
+		{name: "directory pattern", path: "dir", patterns: []string{directoryPattern}, expectedIgnored: true},
+		{name: "exclusion pattern", path: "node/item.txt", patterns: []string{exclusionPattern}, expectedIgnored: true},
+		{name: "no match", path: "keep.txt", patterns: []string{filePatternIgnore}, expectedIgnored: false},
+	}
+	for _, testCase := range testCases {
+		testingHandle.Run(testCase.name, func(testingHandle *testing.T) {
+			ignored := utils.ShouldIgnoreByPath(testCase.path, testCase.patterns)
+			if ignored != testCase.expectedIgnored {
+				testingHandle.Fatalf("ShouldIgnoreByPath(%s) = %v, want %v", testCase.path, ignored, testCase.expectedIgnored)
+			}
+		})
+	}
+}
+
+// TestShouldDisplayBinaryContentByPath verifies binary content display decisions.
+func TestShouldDisplayBinaryContentByPath(testingHandle *testing.T) {
+	testCases := []struct {
+		name             string
+		path             string
+		patterns         []string
+		expectedDecision bool
+	}{
+		{name: "exact match", path: filePatternBinary, patterns: []string{filePatternBinary}, expectedDecision: true},
+		{name: "directory match", path: "bin/a.dat", patterns: []string{binaryPattern}, expectedDecision: true},
+		{name: "no match", path: "other.bin", patterns: []string{binaryPattern}, expectedDecision: false},
+	}
+	for _, testCase := range testCases {
+		testingHandle.Run(testCase.name, func(testingHandle *testing.T) {
+			decision := utils.ShouldDisplayBinaryContentByPath(testCase.path, testCase.patterns)
+			if decision != testCase.expectedDecision {
+				testingHandle.Fatalf("ShouldDisplayBinaryContentByPath(%s) = %v, want %v", testCase.path, decision, testCase.expectedDecision)
+			}
+		})
+	}
+}
+
+// BenchmarkIsBinary provides a basic benchmark for the IsBinary function.
+func BenchmarkIsBinary(benchmarkHandle *testing.B) {
+	data := []byte(base64.StdEncoding.EncodeToString([]byte(binaryFileContent)))
+	for benchmarkIteration := 0; benchmarkIteration < benchmarkHandle.N; benchmarkIteration++ {
+		utils.IsBinary(data)
+	}
+}


### PR DESCRIPTION
## Summary
- add table-driven tests for binary detection and ignore logic
- cover rendering functions for multiple output formats
- verify content and tree data collection honors patterns and binary files

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ba1ce7c0e083279f11143270707bdd