### PR TITLE
Add binary section support in .ignore

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,7 +1,10 @@
+[binary]
+*.png
+
+[ignore]
 .idea/
 *.iml
 .ignore
 .gitignore
 *.txt
 .golangci.yml
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v0.0.11] - 2025-04-20
+
+### Features ✨
+
+1. **Binary Section in `.ignore`**
+    - `.ignore` files now support a `[binary]` section listing patterns whose binary contents are base64-encoded in output.
+    - The legacy `show-binary-content:` directive has been removed.
+
 ## [v0.0.10] - 2025-04-19
 
 ### Features ✨

--- a/PRD.md
+++ b/PRD.md
@@ -74,11 +74,10 @@ optional global exclusion flag (`-e`/`--e`). Explicitly listed files are never f
 
 ### Binary Content Handling
 
-- When the `content` command encounters a binary file, it records the MIME type and omits the content. This occurs when `.ignore` contains no directives:
+- When the `content` command encounters a binary file, it records the MIME type and omits the content. This occurs when `.ignore` contains no `[binary]` section and no legacy directives:
 
   ```
   # .ignore
-  # (no show-binary-content directives)
   ```
 
   ```bash
@@ -89,10 +88,11 @@ optional global exclusion flag (`-e`/`--e`). Explicitly listed files are never f
   End of file: image.png
   ```
 
-- Lines in `.ignore` prefixed with `show-binary-content:` list paths whose binary contents are base64-encoded and included in output:
+- The `[binary]` section in `.ignore` lists patterns whose binary contents are base64-encoded and included in output:
 
   ```
-  show-binary-content: image.png
+  [binary]
+  image.png
   ```
 
   ```bash

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ and **optional embedded documentation** for referenced packages and symbols.
     - Reads patterns from a `.gitignore` file located at the root of each processed directory by default (can be
       disabled with `--no-gitignore`).
     - Skips the `.git` directory unless the `--git` flag is provided.
-    - `.ignore` lines prefixed with `show-binary-content:` designate paths whose binary contents are base64-encoded and included in output.
+    - The `[binary]` section in `.ignore` lists patterns whose binary contents are base64-encoded and included in output.
     - A global exclusion flag (`-e` or `--e`) excludes a designated folder if it appears as a direct child in any
       specified directory.
 - **Command Abbreviations:**
@@ -128,11 +128,10 @@ Exclusion patterns are loaded **only** during directory traversal; explicitly li
 
 ## Binary File Handling
 
-When a binary file is encountered, `ctx` reports its MIME type and omits the content. This is the default behavior when `.ignore` contains no directives:
+When a binary file is encountered, `ctx` reports its MIME type and omits the content. This is the default behavior when `.ignore` contains no `[binary]` section and no legacy directives:
 
 ```
 # .ignore
-# (no show-binary-content directives)
 ```
 
 ```bash
@@ -143,11 +142,11 @@ Mime Type: image/png
 End of file: image.png
 ```
 
-To include binary data, add a `show-binary-content:` directive to `.ignore`. Matched files are emitted as base64-encoded strings:
+To include binary data, add a `[binary]` section to `.ignore` and list matching patterns. Matched files are emitted as base64-encoded strings:
 
 ```
-# .ignore
-show-binary-content: image.png
+[binary]
+image.png
 ```
 
 ```bash

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,11 +12,14 @@ import (
 	"github.com/temirov/ctx/internal/utils"
 )
 
-// gitDirectoryPattern represents the pattern that matches the Git directory.
-const gitDirectoryPattern = utils.GitDirectoryName + "/"
-
-// showBinaryContentDirective marks patterns whose binary content should be displayed.
-const showBinaryContentDirective = "show-binary-content:"
+const (
+	// gitDirectoryPattern represents the pattern that matches the Git directory.
+	gitDirectoryPattern = utils.GitDirectoryName + "/"
+	// binarySectionHeader identifies the section listing binary content patterns.
+	binarySectionHeader = "[binary]"
+	// ignoreSectionHeader identifies the section listing ignore patterns.
+	ignoreSectionHeader = "[ignore]"
+)
 
 // LoadIgnoreFilePatterns reads a specified ignore file and returns ignore patterns and binary content patterns.
 //
@@ -38,17 +41,23 @@ func LoadIgnoreFilePatterns(ignoreFilePath string) ([]string, []string, error) {
 
 	var ignorePatterns []string
 	var binaryContentPatterns []string
+	currentSectionHeader := ignoreSectionHeader
 	scanner := bufio.NewScanner(fileHandle)
 	for scanner.Scan() {
 		trimmedLine := strings.TrimSpace(scanner.Text())
 		if trimmedLine == "" || strings.HasPrefix(trimmedLine, "#") {
 			continue
 		}
-		if strings.HasPrefix(trimmedLine, showBinaryContentDirective) {
-			pattern := strings.TrimSpace(strings.TrimPrefix(trimmedLine, showBinaryContentDirective))
-			if pattern != "" {
-				binaryContentPatterns = append(binaryContentPatterns, pattern)
-			}
+		if strings.EqualFold(trimmedLine, binarySectionHeader) {
+			currentSectionHeader = binarySectionHeader
+			continue
+		}
+		if strings.EqualFold(trimmedLine, ignoreSectionHeader) {
+			currentSectionHeader = ignoreSectionHeader
+			continue
+		}
+		if currentSectionHeader == binarySectionHeader {
+			binaryContentPatterns = append(binaryContentPatterns, trimmedLine)
 			continue
 		}
 		ignorePatterns = append(ignorePatterns, trimmedLine)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	gitDirectoryPattern        = utils.GitDirectoryName + "/"
-	showBinaryContentDirective = "show-binary-content:"
+	gitDirectoryPattern = utils.GitDirectoryName + "/"
+	binarySectionHeader = "[binary]"
 )
 
 // writeTestFile creates a file with the specified content, failing the test on error.
@@ -29,7 +29,7 @@ func TestLoadRecursiveIgnorePatterns(testingHandle *testing.T) {
 	const (
 		nestedIgnoreSubtestName    = "nested ignore files"
 		nestedGitignoreSubtestName = "nested gitignore files"
-		binaryContentSubtestName   = "binary content patterns"
+		binarySectionSubtestName   = "binary section patterns"
 
 		rootIgnorePatternName   = "root.txt"
 		nestedIgnorePatternName = "nested.txt"
@@ -80,15 +80,15 @@ func TestLoadRecursiveIgnorePatterns(testingHandle *testing.T) {
 			expectedBinaryPatterns: []string{},
 		},
 		{
-			name:          binaryContentSubtestName,
+			name:          binarySectionSubtestName,
 			useIgnoreFile: true,
 			createTestFiles: func(testingHandle *testing.T, rootDirectory string) {
-				writeTestFile(testingHandle, filepath.Join(rootDirectory, utils.IgnoreFileName), showBinaryContentDirective+binaryPatternName+"\n")
+				writeTestFile(testingHandle, filepath.Join(rootDirectory, utils.IgnoreFileName), binarySectionHeader+"\n"+binaryPatternName+"\n")
 				nestedDirectoryPath := filepath.Join(rootDirectory, nestedBinaryDirName)
 				if makeDirError := os.MkdirAll(nestedDirectoryPath, 0o755); makeDirError != nil {
 					testingHandle.Fatalf("failed to create nested directory: %v", makeDirError)
 				}
-				writeTestFile(testingHandle, filepath.Join(nestedDirectoryPath, utils.IgnoreFileName), showBinaryContentDirective+binaryPatternName+"\n")
+				writeTestFile(testingHandle, filepath.Join(nestedDirectoryPath, utils.IgnoreFileName), binarySectionHeader+"\n"+binaryPatternName+"\n")
 			},
 			expectedPatterns:       []string{gitDirectoryPattern},
 			expectedBinaryPatterns: []string{binaryPatternName, nestedBinaryDirName + "/" + binaryPatternName},

--- a/tests/ctx_test.go
+++ b/tests/ctx_test.go
@@ -60,10 +60,11 @@ const (
 
 	usageSnippet = "Usage:\n  ctx"
 
-	binaryFixtureFileName      = "fixture.png"
-	expectedBinaryMimeType     = "image/png"
-	ignoreFileName             = ".ignore"
-	showBinaryContentDirective = "show-binary-content:"
+	binaryFixtureFileName  = "fixture.png"
+	expectedBinaryMimeType = "image/png"
+	ignoreFileName         = ".ignore"
+	// binarySectionHeader identifies the section that lists binary content patterns in an ignore file.
+	binarySectionHeader        = "[binary]"
 	unmatchedBinaryFixtureName = "unmatched.bin"
 	onePixelPNGBase64Content   = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII="
 )
@@ -681,7 +682,7 @@ func TestCTX(testingHandle *testing.T) {
 				if decodeError != nil {
 					t.Fatalf("failed to decode binary fixture: %v", decodeError)
 				}
-				ignoreContent := showBinaryContentDirective + unmatchedBinaryFixtureName + "\n"
+				ignoreContent := binarySectionHeader + "\n" + unmatchedBinaryFixtureName + "\n"
 				return setupTestDirectory(t, map[string]string{
 					binaryFixtureFileName: string(binaryBytes),
 					ignoreFileName:        ignoreContent,
@@ -705,7 +706,7 @@ func TestCTX(testingHandle *testing.T) {
 			},
 		},
 		{
-			name: "BinaryFileContentShowDirective",
+			name: "BinaryFileContentBinarySection",
 			arguments: []string{
 				appTypes.CommandContent,
 				".",
@@ -715,7 +716,7 @@ func TestCTX(testingHandle *testing.T) {
 				if decodeError != nil {
 					t.Fatalf("failed to decode binary fixture: %v", decodeError)
 				}
-				ignoreContent := showBinaryContentDirective + binaryFixtureFileName + "\n"
+				ignoreContent := binarySectionHeader + "\n" + binaryFixtureFileName + "\n"
 				return setupTestDirectory(t, map[string]string{
 					binaryFixtureFileName: string(binaryBytes),
 					ignoreFileName:        ignoreContent,


### PR DESCRIPTION
## Summary
- allow `[binary]` sections in `.ignore` to specify patterns whose binary contents are emitted
- remove support for legacy `show-binary-content:` directives
- document new section semantics

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ba288ca8f88327afe91dba33e1272a