### PR TITLE
Ensure MIME type for all files

### DIFF
--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/temirov/ctx/internal/commands"
 	"github.com/temirov/ctx/internal/types"
+	"github.com/temirov/ctx/internal/utils"
 )
 
 // textFileName defines the text file name used in tests.
@@ -15,6 +16,9 @@ const textFileName = "example.txt"
 
 // textFileContent provides the text content written to the text file.
 const textFileContent = "hello"
+
+// textMimeTypeExpected is the expected MIME type for the text file.
+const textMimeTypeExpected = "text/plain; charset=utf-8"
 
 // binaryFileName defines the binary file name used in tests.
 const binaryFileName = "example.bin"
@@ -52,8 +56,8 @@ func TestGetContentData(testingInstance *testing.T) {
 			ignorePatterns:       nil,
 			binaryContentPattern: nil,
 			expectedOutputs: []types.FileOutput{
-				{Path: textPath, Type: types.NodeTypeFile, Content: textFileContent, MimeType: ""},
-				{Path: binaryPath, Type: types.NodeTypeBinary, Content: "", MimeType: binaryMimeTypeExpected},
+				{Path: textPath, Type: types.NodeTypeFile, Content: textFileContent, MimeType: textMimeTypeExpected},
+				{Path: binaryPath, Type: types.NodeTypeBinary, Content: utils.EmptyString, MimeType: binaryMimeTypeExpected},
 			},
 		},
 		{
@@ -61,7 +65,7 @@ func TestGetContentData(testingInstance *testing.T) {
 			ignorePatterns:       []string{binaryFileName},
 			binaryContentPattern: nil,
 			expectedOutputs: []types.FileOutput{
-				{Path: textPath, Type: types.NodeTypeFile, Content: textFileContent, MimeType: ""},
+				{Path: textPath, Type: types.NodeTypeFile, Content: textFileContent, MimeType: textMimeTypeExpected},
 			},
 		},
 		{
@@ -69,7 +73,7 @@ func TestGetContentData(testingInstance *testing.T) {
 			ignorePatterns:       nil,
 			binaryContentPattern: []string{binaryFileName},
 			expectedOutputs: []types.FileOutput{
-				{Path: textPath, Type: types.NodeTypeFile, Content: textFileContent, MimeType: ""},
+				{Path: textPath, Type: types.NodeTypeFile, Content: textFileContent, MimeType: textMimeTypeExpected},
 				{Path: binaryPath, Type: types.NodeTypeBinary, Content: binaryBase64Content, MimeType: binaryMimeTypeExpected},
 			},
 		},

--- a/internal/commands/content.go
+++ b/internal/commands/content.go
@@ -58,14 +58,13 @@ func GetContentData(rootPath string, ignorePatterns []string, binaryContentPatte
 
 		fileType := types.NodeTypeFile
 		fileContent := string(fileBytes)
-		mimeType := ""
+		mimeType := utils.DetectMimeType(walkedPath)
 		if utils.IsBinary(fileBytes) {
 			fileType = types.NodeTypeBinary
-			mimeType = utils.DetectMimeType(walkedPath)
 			if utils.ShouldDisplayBinaryContentByPath(relativePath, binaryContentPatterns) {
 				fileContent = base64.StdEncoding.EncodeToString(fileBytes)
 			} else {
-				fileContent = ""
+				fileContent = utils.EmptyString
 			}
 		}
 

--- a/internal/utils/constants.go
+++ b/internal/utils/constants.go
@@ -1,0 +1,4 @@
+package utils
+
+// EmptyString represents a reusable empty string constant.
+const EmptyString = ""

--- a/internal/utils/mime.go
+++ b/internal/utils/mime.go
@@ -6,22 +6,25 @@ import (
 	"os"
 )
 
-const unknownMimeType = ""
+const (
+	// UnknownMimeType is returned when the MIME type of a file cannot be determined.
+	UnknownMimeType = EmptyString
+)
 
 // DetectMimeType determines the MIME type of the file at the provided path by
 // reading up to sniffLen bytes and passing them to http.DetectContentType. It
-// returns an empty string if the file cannot be read.
+// returns UnknownMimeType if the file cannot be read.
 func DetectMimeType(filePath string) string {
 	openedFile, openError := os.Open(filePath)
 	if openError != nil {
-		return unknownMimeType
+		return UnknownMimeType
 	}
 	defer openedFile.Close()
 
 	buffer := make([]byte, sniffLen)
 	bytesRead, readError := openedFile.Read(buffer)
 	if readError != nil && readError != io.EOF {
-		return unknownMimeType
+		return UnknownMimeType
 	}
 
 	return http.DetectContentType(buffer[:bytesRead])


### PR DESCRIPTION
## Summary
- detect MIME type for every file during content collection
- centralize empty string as `utils.EmptyString` and expose `utils.UnknownMimeType`
- adjust tests for text MIME type expectations

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ba44f84bf88327b89d862cd0cda0b9