### PR TITLE
Populate tree nodes with MIME types

### DIFF
--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -121,7 +121,7 @@ func TestGetTreeData(testingInstance *testing.T) {
 			testName:       "includes binary file",
 			ignorePatterns: nil,
 			expectedChildren: []types.TreeOutputNode{
-				{Path: textPath, Name: textFileName, Type: types.NodeTypeFile},
+				{Path: textPath, Name: textFileName, Type: types.NodeTypeFile, MimeType: textMimeTypeExpected},
 				{Path: binaryPath, Name: binaryFileName, Type: types.NodeTypeBinary, MimeType: binaryMimeTypeExpected},
 			},
 		},
@@ -129,7 +129,7 @@ func TestGetTreeData(testingInstance *testing.T) {
 			testName:       "ignores by pattern",
 			ignorePatterns: []string{binaryFileName},
 			expectedChildren: []types.TreeOutputNode{
-				{Path: textPath, Name: textFileName, Type: types.NodeTypeFile},
+				{Path: textPath, Name: textFileName, Type: types.NodeTypeFile, MimeType: textMimeTypeExpected},
 			},
 		},
 	}

--- a/internal/commands/tree.go
+++ b/internal/commands/tree.go
@@ -72,10 +72,10 @@ func buildTreeNodes(currentDirectoryPath string, rootDirectoryPath string, ignor
 		} else {
 			if utils.IsFileBinary(childPath) {
 				node.Type = types.NodeTypeBinary
-				node.MimeType = utils.DetectMimeType(childPath)
 			} else {
 				node.Type = types.NodeTypeFile
 			}
+			node.MimeType = utils.DetectMimeType(childPath)
 		}
 		nodes = append(nodes, node)
 	}


### PR DESCRIPTION
## Summary
- detect MIME type for all file nodes in tree command
- expect MIME type for text files in tree command tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ba486d276483279b8b179b1f935882