### PR TITLE
Include MIME types for text files in structured outputs

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -74,7 +74,7 @@ optional global exclusion flag (`-e`/`--e`). Explicitly listed files are never f
 
 ### Binary Content Handling
 
-- When the `content` command encounters a binary file, it records the MIME type and omits the content. This occurs when `.ignore` contains no `[binary]` section and no legacy directives:
+- When the `content` command encounters a binary file, it omits the content in raw output. JSON and XML outputs include a `mimeType` field for every file. This occurs when `.ignore` contains no `[binary]` section and no legacy directives:
 
   ```
   # .ignore
@@ -83,7 +83,6 @@ optional global exclusion flag (`-e`/`--e`). Explicitly listed files are never f
   ```bash
   ctx content image.png --format raw
   File: image.png
-  Mime Type: image/png
   (binary content omitted)
   End of file: image.png
   ```

--- a/README.md
+++ b/README.md
@@ -122,13 +122,15 @@ ctx callchain github.com/temirov/ctx/internal/commands.GetContentData --depth 2 
 | json   | `[]TreeOutputNode`             | `[]FileOutput`                             | `CallChainOutput` |
 | xml    | `result/code/item` nodes       | `result/code/item` nodes                   | `callchains/callchain` |
 
+All JSON and XML outputs include a `mimeType` field for every file. Raw output never displays MIME type information.
+
 ## Configuration
 
 Exclusion patterns are loaded **only** during directory traversal; explicitly listed file paths are never ignored.
 
 ## Binary File Handling
 
-When a binary file is encountered, `ctx` reports its MIME type and omits the content. This is the default behavior when `.ignore` contains no `[binary]` section and no legacy directives:
+When a binary file is encountered, `ctx` omits its content in raw output. JSON and XML results always include the file's MIME type. This is the default behavior when `.ignore` contains no `[binary]` section and no legacy directives:
 
 ```
 # .ignore
@@ -137,7 +139,6 @@ When a binary file is encountered, `ctx` reports its MIME type and omits the con
 ```bash
 ctx content image.png --format raw
 File: image.png
-Mime Type: image/png
 (binary content omitted)
 End of file: image.png
 ```

--- a/cmd/ctx/main.go
+++ b/cmd/ctx/main.go
@@ -340,11 +340,10 @@ func runTreeOrContentCommand(
 			}
 		} else {
 			if commandName == types.CommandTree {
+				mimeType := utils.DetectMimeType(info.AbsolutePath)
 				nodeType := types.NodeTypeFile
-				mimeType := ""
 				if utils.IsFileBinary(info.AbsolutePath) {
 					nodeType = types.NodeTypeBinary
-					mimeType = utils.DetectMimeType(info.AbsolutePath)
 				}
 				collected = append(collected, &types.TreeOutputNode{
 					Path:     info.AbsolutePath,
@@ -358,13 +357,12 @@ func runTreeOrContentCommand(
 					fmt.Fprintf(os.Stderr, commands.WarningFileReadFormat, info.AbsolutePath, fileReadError)
 					continue
 				}
+				mimeType := utils.DetectMimeType(info.AbsolutePath)
 				fileType := types.NodeTypeFile
 				content := string(fileBytes)
-				mimeType := ""
 				if utils.IsBinary(fileBytes) {
 					fileType = types.NodeTypeBinary
 					content = ""
-					mimeType = utils.DetectMimeType(info.AbsolutePath)
 				}
 				collected = append(collected, &types.FileOutput{
 					Path:     info.AbsolutePath,

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -121,7 +121,7 @@ func TestGetTreeData(testingInstance *testing.T) {
 			testName:       "includes binary file",
 			ignorePatterns: nil,
 			expectedChildren: []types.TreeOutputNode{
-				{Path: textPath, Name: textFileName, Type: types.NodeTypeFile},
+				{Path: textPath, Name: textFileName, Type: types.NodeTypeFile, MimeType: textMimeTypeExpected},
 				{Path: binaryPath, Name: binaryFileName, Type: types.NodeTypeBinary, MimeType: binaryMimeTypeExpected},
 			},
 		},
@@ -129,7 +129,7 @@ func TestGetTreeData(testingInstance *testing.T) {
 			testName:       "ignores by pattern",
 			ignorePatterns: []string{binaryFileName},
 			expectedChildren: []types.TreeOutputNode{
-				{Path: textPath, Name: textFileName, Type: types.NodeTypeFile},
+				{Path: textPath, Name: textFileName, Type: types.NodeTypeFile, MimeType: textMimeTypeExpected},
 			},
 		},
 	}

--- a/internal/commands/tree.go
+++ b/internal/commands/tree.go
@@ -70,9 +70,9 @@ func buildTreeNodes(currentDirectoryPath string, rootDirectoryPath string, ignor
 				node.Children = childNodes
 			}
 		} else {
+			node.MimeType = utils.DetectMimeType(childPath)
 			if utils.IsFileBinary(childPath) {
 				node.Type = types.NodeTypeBinary
-				node.MimeType = utils.DetectMimeType(childPath)
 			} else {
 				node.Type = types.NodeTypeFile
 			}

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -9,6 +9,9 @@ import (
 	"github.com/temirov/ctx/internal/types"
 )
 
+// textMimeTypeExpected defines the MIME type expected for text files.
+const textMimeTypeExpected = "text/plain; charset=utf-8"
+
 // callChainRawExpected defines the expected raw rendering of a call chain.
 const callChainRawExpected = "----- CALLCHAIN METADATA -----\n" +
 	"Target Function: target\n" +
@@ -62,7 +65,8 @@ const jsonExpected = "{\n" +
 	"    {\n" +
 	"      \"path\": \"file.txt\",\n" +
 	"      \"type\": \"file\",\n" +
-	"      \"content\": \"data\"\n" +
+	"      \"content\": \"data\",\n" +
+	"      \"mimeType\": \"" + textMimeTypeExpected + "\"\n" +
 	"    }\n" +
 	"  ]\n" +
 	"}"
@@ -70,7 +74,7 @@ const jsonExpected = "{\n" +
 // TestRenderJSON verifies RenderJSON output and deduplication.
 func TestRenderJSON(testingInstance *testing.T) {
 	docs := []types.DocumentationEntry{{Kind: "kind", Name: "name", Doc: "doc"}, {Kind: "kind", Name: "name", Doc: "doc"}}
-	items := []interface{}{&types.FileOutput{Path: "file.txt", Type: types.NodeTypeFile, Content: "data"}, &types.FileOutput{Path: "file.txt", Type: types.NodeTypeFile, Content: "data"}}
+	items := []interface{}{&types.FileOutput{Path: "file.txt", Type: types.NodeTypeFile, Content: "data", MimeType: textMimeTypeExpected}, &types.FileOutput{Path: "file.txt", Type: types.NodeTypeFile, Content: "data", MimeType: textMimeTypeExpected}}
 	actual, err := output.RenderJSON(docs, items)
 	if err != nil {
 		testingInstance.Fatalf("render json error: %v", err)
@@ -95,6 +99,7 @@ const xmlExpected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
 	"      <path>file.txt</path>\n" +
 	"      <type>file</type>\n" +
 	"      <content>data</content>\n" +
+	"      <mimeType>" + textMimeTypeExpected + "</mimeType>\n" +
 	"      <documentation></documentation>\n" +
 	"    </item>\n" +
 	"  </code>\n" +
@@ -103,7 +108,7 @@ const xmlExpected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
 // TestRenderXML verifies RenderXML output and deduplication.
 func TestRenderXML(testingInstance *testing.T) {
 	docs := []types.DocumentationEntry{{Kind: "kind", Name: "name", Doc: "doc"}, {Kind: "kind", Name: "name", Doc: "doc"}}
-	items := []interface{}{&types.FileOutput{Path: "file.txt", Type: types.NodeTypeFile, Content: "data"}, &types.FileOutput{Path: "file.txt", Type: types.NodeTypeFile, Content: "data"}}
+	items := []interface{}{&types.FileOutput{Path: "file.txt", Type: types.NodeTypeFile, Content: "data", MimeType: textMimeTypeExpected}, &types.FileOutput{Path: "file.txt", Type: types.NodeTypeFile, Content: "data", MimeType: textMimeTypeExpected}}
 	actual, err := output.RenderXML(docs, items)
 	if err != nil {
 		testingInstance.Fatalf("render xml error: %v", err)
@@ -125,7 +130,7 @@ const rawExpected = "--- Documentation ---\n" +
 // TestRenderRaw verifies RenderRaw printing.
 func TestRenderRaw(testingInstance *testing.T) {
 	docs := []types.DocumentationEntry{{Kind: "kind", Name: "name", Doc: "doc"}}
-	items := []interface{}{&types.FileOutput{Path: "file.txt", Type: types.NodeTypeFile, Content: "data"}}
+	items := []interface{}{&types.FileOutput{Path: "file.txt", Type: types.NodeTypeFile, Content: "data", MimeType: textMimeTypeExpected}}
 	reader, writer, pipeError := os.Pipe()
 	if pipeError != nil {
 		testingInstance.Fatalf("pipe error: %v", pipeError)


### PR DESCRIPTION
## Summary
- report MIME types for text files in tree data and CLI file handling
- ensure JSON and XML outputs always include mimeType while raw output omits it
- document universal mimeType presence for structured formats

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ba4c181010832792e647e24892d258