### PR TITLE
build: fix ctx binary build path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,10 @@ jobs:
       - name: BuildCTXBinaries
         run: |
           mkdir -p dist
-          GOOS=linux   GOARCH=amd64   go build -ldflags="-s -w" -o dist/ctx_linux_amd64 main.go
-          GOOS=darwin  GOARCH=amd64   go build -ldflags="-s -w" -o dist/ctx_darwin_amd64 main.go
-          GOOS=darwin  GOARCH=arm64   go build -ldflags="-s -w" -o dist/ctx_darwin_arm64 main.go
-          GOOS=windows GOARCH=amd64   go build -ldflags="-s -w" -o dist/ctx_windows_amd64.exe main.go
+          GOOS=linux   GOARCH=amd64   go build -ldflags="-s -w" -o dist/ctx_linux_amd64   ./cmd/ctx
+          GOOS=darwin  GOARCH=amd64   go build -ldflags="-s -w" -o dist/ctx_darwin_amd64  ./cmd/ctx
+          GOOS=darwin  GOARCH=arm64   go build -ldflags="-s -w" -o dist/ctx_darwin_arm64 ./cmd/ctx
+          GOOS=windows GOARCH=amd64   go build -ldflags="-s -w" -o dist/ctx_windows_amd64.exe ./cmd/ctx
 
       - name: GenerateChecksums
         run: |


### PR DESCRIPTION
## Summary
- build binaries from ./cmd/ctx to ensure proper main resolution

## Testing
- `go test ./...` *(fails: github.com/temirov/ctx/tests 2.145s)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6c6d394c83278d046a799f1c00ea