### PR TITLE
Allow multiple exclusion patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Improvements ⚙️
 
+* Support repeatable exclusion flag with glob pattern matching for tree and content commands.
 * Improve help output and adopt a custom usage template. (#55 a99dc40, a93b618, #47 aa8f792)
 * Show command aliases in help (Cobra help template override). (#45 3de79fb, c311f97)
 * Refine path-based ignore handling and centralize ignore constants/messages. (#51 ff3756a, #41 ac2da74, 22bb964, a64d9cd, 59c829b)

--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ and **optional embedded documentation** for referenced packages and symbols.
       disabled with `--no-gitignore`).
     - Skips the `.git` directory unless the `--git` flag is provided.
     - The `[binary]` section in `.ignore` lists patterns whose binary contents are base64-encoded and included in output.
-    - A global exclusion flag (`-e` or `--e`) excludes a designated folder if it appears as a direct child in any
-      specified directory.
+    - A repeatable exclusion flag (`-e` or `--e`) skips paths matching the supplied patterns.
 - **Command Abbreviations:**
     - `t` is an alias for `tree`.
     - `c` is an alias for `content`.
@@ -85,7 +84,7 @@ ctx <tree|t|content|c|callchain|cc> [arguments...] [flags]
 
 | Flag                  | Applies to         | Description |
 |-----------------------|--------------------|---------------------------------------------------------------|
-| `-e, --e <folder>`    | tree, content      | Exclude a direct-child folder during directory traversal. |
+| `-e, --e <pattern>`   | tree, content      | Exclude paths matching the pattern; repeat for multiple patterns. |
 | `--no-gitignore`      | tree, content      | Disable loading of `.gitignore` files. |
 | `--no-ignore`         | tree, content      | Disable loading of `.ignore` files. |
 | `--git`               | tree, content      | Include the `.git` directory during traversal. |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,8 +70,8 @@ func LoadIgnoreFilePatterns(ignoreFilePath string) ([]string, []string, error) {
 
 // LoadCombinedIgnorePatterns aggregates patterns from .ignore and/or .gitignore files within a directory.
 // The .git directory is excluded by default unless includeGit is true.
-// The exclusion folder pattern is appended when provided.
-func LoadCombinedIgnorePatterns(absoluteDirectoryPath string, exclusionFolder string, useGitignore bool, useIgnoreFile bool, includeGit bool) ([]string, error) {
+// The provided exclusionPatterns are appended to the result.
+func LoadCombinedIgnorePatterns(absoluteDirectoryPath string, exclusionPatterns []string, useGitignore bool, useIgnoreFile bool, includeGit bool) ([]string, error) {
 	var combinedPatterns []string
 
 	if useIgnoreFile {
@@ -98,19 +98,13 @@ func LoadCombinedIgnorePatterns(absoluteDirectoryPath string, exclusionFolder st
 
 	deduplicatedFilePatterns := utils.DeduplicatePatterns(combinedPatterns)
 
-	trimmedExclusion := strings.TrimSpace(exclusionFolder)
-	if trimmedExclusion != "" {
-		normalizedExclusion := strings.TrimSuffix(trimmedExclusion, "/")
-		exclusionPattern := utils.ExclusionPrefix + normalizedExclusion
-		isPresent := false
-		for _, pattern := range deduplicatedFilePatterns {
-			if pattern == exclusionPattern {
-				isPresent = true
-				break
-			}
+	for _, pattern := range exclusionPatterns {
+		trimmedPattern := strings.TrimSpace(pattern)
+		if trimmedPattern == "" {
+			continue
 		}
-		if !isPresent {
-			deduplicatedFilePatterns = append(deduplicatedFilePatterns, exclusionPattern)
+		if !utils.ContainsString(deduplicatedFilePatterns, trimmedPattern) {
+			deduplicatedFilePatterns = append(deduplicatedFilePatterns, trimmedPattern)
 		}
 	}
 
@@ -122,8 +116,8 @@ func LoadCombinedIgnorePatterns(absoluteDirectoryPath string, exclusionFolder st
 // path relative to rootDirectoryPath. For example, a pattern listed in utils.GitIgnoreFileName within a child directory is
 // returned with the directory's relative path prepended. Patterns from utils.GitIgnoreFileName are handled the same way as
 // those from utils.IgnoreFileName. The directory named utils.GitDirectoryName is ignored by default unless includeGit is
-// true. When exclusionFolder is provided, a pattern using utils.ExclusionPrefix is appended.
-func LoadRecursiveIgnorePatterns(rootDirectoryPath string, exclusionFolder string, useGitignore bool, useIgnoreFile bool, includeGit bool) ([]string, []string, error) {
+// true. The provided exclusionPatterns are appended to the result.
+func LoadRecursiveIgnorePatterns(rootDirectoryPath string, exclusionPatterns []string, useGitignore bool, useIgnoreFile bool, includeGit bool) ([]string, []string, error) {
 	var aggregatedPatterns []string
 	var aggregatedBinaryContentPatterns []string
 
@@ -183,19 +177,13 @@ func LoadRecursiveIgnorePatterns(rootDirectoryPath string, exclusionFolder strin
 	deduplicatedPatterns := utils.DeduplicatePatterns(aggregatedPatterns)
 	deduplicatedBinaryPatterns := utils.DeduplicatePatterns(aggregatedBinaryContentPatterns)
 
-	trimmedExclusion := strings.TrimSpace(exclusionFolder)
-	if trimmedExclusion != "" {
-		normalizedExclusion := strings.TrimSuffix(trimmedExclusion, "/")
-		exclusionPattern := utils.ExclusionPrefix + normalizedExclusion
-		isPresent := false
-		for _, pattern := range deduplicatedPatterns {
-			if pattern == exclusionPattern {
-				isPresent = true
-				break
-			}
+	for _, pattern := range exclusionPatterns {
+		trimmedPattern := strings.TrimSpace(pattern)
+		if trimmedPattern == "" {
+			continue
 		}
-		if !isPresent {
-			deduplicatedPatterns = append(deduplicatedPatterns, exclusionPattern)
+		if !utils.ContainsString(deduplicatedPatterns, trimmedPattern) {
+			deduplicatedPatterns = append(deduplicatedPatterns, trimmedPattern)
 		}
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -100,7 +100,7 @@ func TestLoadRecursiveIgnorePatterns(testingHandle *testing.T) {
 			rootDirectory := testingHandle.TempDir()
 			testCase.createTestFiles(testingHandle, rootDirectory)
 
-			patternList, binaryPatternList, loadError := config.LoadRecursiveIgnorePatterns(rootDirectory, "", testCase.useGitignore, testCase.useIgnoreFile, false)
+			patternList, binaryPatternList, loadError := config.LoadRecursiveIgnorePatterns(rootDirectory, nil, testCase.useGitignore, testCase.useIgnoreFile, false)
 			if loadError != nil {
 				testingHandle.Fatalf("LoadRecursiveIgnorePatterns failed: %v", loadError)
 			}
@@ -117,5 +117,26 @@ func TestLoadRecursiveIgnorePatterns(testingHandle *testing.T) {
 				testingHandle.Fatalf("unexpected binary content patterns: got %v want %v", binaryPatternList, testCase.expectedBinaryPatterns)
 			}
 		})
+	}
+}
+
+// TestLoadRecursiveIgnorePatternsAddsExclusions verifies that provided exclusion patterns are included.
+func TestLoadRecursiveIgnorePatternsAddsExclusions(testingHandle *testing.T) {
+	const (
+		toolsPattern  = "tools"
+		githubPattern = ".github"
+		yamlPattern   = "*.yml"
+	)
+	rootDirectory := testingHandle.TempDir()
+	patterns := []string{toolsPattern, githubPattern, yamlPattern}
+	expectedPatterns := append([]string{gitDirectoryPattern}, patterns...)
+	actualPatterns, _, loadError := config.LoadRecursiveIgnorePatterns(rootDirectory, patterns, false, false, false)
+	if loadError != nil {
+		testingHandle.Fatalf("LoadRecursiveIgnorePatterns failed: %v", loadError)
+	}
+	sort.Strings(actualPatterns)
+	sort.Strings(expectedPatterns)
+	if !reflect.DeepEqual(actualPatterns, expectedPatterns) {
+		testingHandle.Fatalf("unexpected patterns: got %v want %v", actualPatterns, expectedPatterns)
 	}
 }


### PR DESCRIPTION
## Summary
- allow repeating `-e` to ignore multiple path patterns
- append provided patterns to config ignore lists
- document and test exclusion pattern flag

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bb352f36cc83278100bb90b12efc7b