### PR TITLE
docs: make json the default output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ and **optional embedded documentation** for referenced packages and symbols.
 - **Call Chain Analysis:** Analyzes the call graph for a specified function using the `callchain` command. Provide the
   fully qualified (or suffix) function name as the sole argument. The traversal depth is configurable with `--depth`.
 - **Embedded Documentation (`--doc`):** When the `--doc` flag is used with the `content` or `callchain` command,
-  ctx embeds documentation for imported third-party packages and referenced functions in the output (both *json* and
+  ctx embeds documentation for imported third-party packages and referenced functions in the output (*json*, *xml*, and
   *raw* formats).
 - **Output Formats:** Supports **json** output (default), **raw** text, and **xml** output using the `--format` flag for all
   commands.
@@ -21,17 +21,21 @@ and **optional embedded documentation** for referenced packages and symbols.
       `children` array.
     - *Raw format:* Recursively displays the directory structure for each specified directory in a tree-like format,
       listing explicitly provided file paths with `[File]`.
+    - *XML format:* Produces `result/code/item` nodes capturing the tree structure.
 - **Content Command (`content`, `c`):**
     - *JSON format:* Outputs a JSON array of objects, each containing the `path`, `type`, and `content` of successfully
       read files. Documentation (when `--doc` is used) is included in a `documentation` field.
     - *Raw format:* Outputs the content of explicitly provided files and concatenates contents of files within
       directories, separated by headers. When `--doc` is used, documentation for imported packages and symbols is
       appended after each file block.
+    - *XML format:* Emits `result/code/item` nodes that mirror the JSON structure, including optional documentation.
 - **Call Chain Command (`callchain`, `cc`):**
     - *JSON format:* Outputs a JSON object with `targetFunction`, `callers`, `callees`, a `functions` map (name →
       source), and (when `--doc`) a `documentation` array.
     - *Raw format:* Displays the target function, its callers, and callees, followed by the source code of these
       functions. When `--doc` is used, documentation for referenced external packages/functions is appended.
+    - *XML format:* Generates `<callchains><callchain>` elements containing the target, callers, callees, and
+      optional documentation.
     - *Depth control (`--depth`):* Limits traversal of callers and callees. The default depth is `1`, which yields only
       direct callers and callees. For example:
 
@@ -107,10 +111,10 @@ Output file contents with embedded docs (JSON by default):
 ctx content main.go pkg --doc
 ```
 
-Analyze the call chain for a function including docs:
+Analyze the call chain for a function in XML including docs:
 
 ```bash
-ctx callchain github.com/temirov/ctx/internal/commands.GetContentData --depth 2 --doc --format raw
+ctx callchain github.com/temirov/ctx/internal/commands.GetContentData --depth 2 --doc --format xml
 ```
 
 ## Output Formats

--- a/README.md
+++ b/README.md
@@ -12,26 +12,26 @@ and **optional embedded documentation** for referenced packages and symbols.
 - **Call Chain Analysis:** Analyzes the call graph for a specified function using the `callchain` command. Provide the
   fully qualified (or suffix) function name as the sole argument. The traversal depth is configurable with `--depth`.
 - **Embedded Documentation (`--doc`):** When the `--doc` flag is used with the `content` or `callchain` command,
-  ctx embeds documentation for imported third-party packages and referenced functions in the output (both *raw* and
-  *json* formats).
-- **Output Formats:** Supports **raw** text output (default), **json**, and **xml** output using the `--format` flag for all
+  ctx embeds documentation for imported third-party packages and referenced functions in the output (both *json* and
+  *raw* formats).
+- **Output Formats:** Supports **json** output (default), **raw** text, and **xml** output using the `--format` flag for all
   commands.
 - **Tree Command (`tree`, `t`):**
-    - *Raw format:* Recursively displays the directory structure for each specified directory in a tree-like format,
-      listing explicitly provided file paths with `[File]`.
     - *JSON format:* Outputs a JSON array where each element represents an input path. Directories include a nested
       `children` array.
+    - *Raw format:* Recursively displays the directory structure for each specified directory in a tree-like format,
+      listing explicitly provided file paths with `[File]`.
 - **Content Command (`content`, `c`):**
+    - *JSON format:* Outputs a JSON array of objects, each containing the `path`, `type`, and `content` of successfully
+      read files. Documentation (when `--doc` is used) is included in a `documentation` field.
     - *Raw format:* Outputs the content of explicitly provided files and concatenates contents of files within
       directories, separated by headers. When `--doc` is used, documentation for imported packages and symbols is
       appended after each file block.
-    - *JSON format:* Outputs a JSON array of objects, each containing the `path`, `type`, and `content` of successfully
-      read files. Documentation (when `--doc` is used) is included in a `documentation` field.
 - **Call Chain Command (`callchain`, `cc`):**
-    - *Raw format:* Displays the target function, its callers, and callees, followed by the source code of these
-      functions. When `--doc` is used, documentation for referenced external packages/functions is appended.
     - *JSON format:* Outputs a JSON object with `targetFunction`, `callers`, `callees`, a `functions` map (name →
       source), and (when `--doc`) a `documentation` array.
+    - *Raw format:* Displays the target function, its callers, and callees, followed by the source code of these
+      functions. When `--doc` is used, documentation for referenced external packages/functions is appended.
     - *Depth control (`--depth`):* Limits traversal of callers and callees. The default depth is `1`, which yields only
       direct callers and callees. For example:
 
@@ -88,7 +88,7 @@ ctx <tree|t|content|c|callchain|cc> [arguments...] [flags]
 | `--no-gitignore`      | tree, content      | Disable loading of `.gitignore` files. |
 | `--no-ignore`         | tree, content      | Disable loading of `.ignore` files. |
 | `--git`               | tree, content      | Include the `.git` directory during traversal. |
-| `--format <raw|json|xml>` | all commands       | Select output format (default `raw`). |
+| `--format <raw|json|xml>` | all commands       | Select output format (default `json`). |
 | `--doc`               | content, callchain | Embed documentation for referenced external packages and symbols into the output. |
 | `--depth <number>`    | callchain          | Limit call graph traversal depth (default `1`). |
 | `--version`           | all commands       | Print ctx version and exit. |
@@ -98,13 +98,13 @@ ctx <tree|t|content|c|callchain|cc> [arguments...] [flags]
 Display a raw tree view excluding `dist` folders:
 
 ```bash
-ctx tree projectA projectB -e dist
+ctx tree projectA projectB -e dist --format raw
 ```
 
-Output file contents in JSON with embedded docs:
+Output file contents with embedded docs (JSON by default):
 
 ```bash
-ctx content main.go pkg --doc --format json
+ctx content main.go pkg --doc
 ```
 
 Analyze the call chain for a function including docs:
@@ -150,7 +150,7 @@ image.png
 ```
 
 ```bash
-ctx content . --format json
+ctx content .
 [
   {
     "path": "image.png",


### PR DESCRIPTION
## Summary
- document JSON as the default output format
- update examples to show raw output requires `--format raw`

## Testing
- `go test -run . ./...` *(fails: command produced no output and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68bb597293848327ad58471a2150c961