### PR TITLE
refactor: centralize dedupe key prefixes

### DIFF
--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -29,6 +29,13 @@ const (
 	mimeTypeLabel        = "Mime Type: "
 	binaryNodeFormat     = "[Binary] %s (%s%s)\n"
 	binaryTreeFormat     = "%s[Binary] %s (%s%s)\n"
+
+	// filePrefix is the key prefix used when deduplicating file outputs.
+	filePrefix = "file:"
+	// nodePrefix is the key prefix used when deduplicating tree nodes.
+	nodePrefix = "node:"
+	// callChainPrefix is the key prefix used when deduplicating call chain outputs.
+	callChainPrefix = "callchain:"
 )
 
 // RenderCallChainRaw returns the call‑chain output in raw text format.
@@ -251,11 +258,11 @@ func dedupeCollectedItems(items []interface{}) []interface{} {
 		var key string
 		switch v := item.(type) {
 		case *types.FileOutput:
-			key = "file:" + v.Path
+			key = filePrefix + v.Path
 		case *types.TreeOutputNode:
-			key = "node:" + v.Path
+			key = nodePrefix + v.Path
 		case *types.CallChainOutput:
-			key = "callchain:" + v.TargetFunction
+			key = callChainPrefix + v.TargetFunction
 		default:
 			continue
 		}


### PR DESCRIPTION
## Summary
- define constants for file, node, and call chain key prefixes
- use prefix constants in dedupeCollectedItems to build dedupe keys

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bc7b76f1e08327b9d95a263915e254