### PR TITLE
refactor: centralize error log format constant

### DIFF
--- a/cmd/ctx/main.go
+++ b/cmd/ctx/main.go
@@ -4,13 +4,12 @@ import (
 	"log"
 
 	"github.com/temirov/ctx/internal/cli"
+	"github.com/temirov/ctx/internal/utils"
 )
-
-const errorLogFormat = "Error: %v"
 
 // main is the entry point for the ctx command.
 func main() {
 	if err := cli.Execute(); err != nil {
-		log.Fatalf(errorLogFormat, err)
+		log.Fatalf(utils.ErrorLogFormat, err)
 	}
 }

--- a/internal/utils/constants.go
+++ b/internal/utils/constants.go
@@ -2,3 +2,6 @@ package utils
 
 // EmptyString represents a reusable empty string constant.
 const EmptyString = ""
+
+// ErrorLogFormat defines the formatting string for error log messages.
+const ErrorLogFormat = "Error: %v"

--- a/main.go
+++ b/main.go
@@ -4,13 +4,12 @@ import (
 	"log"
 
 	"github.com/temirov/ctx/internal/cli"
+	"github.com/temirov/ctx/internal/utils"
 )
-
-const errorLogFormat = "Error: %v"
 
 // main is the entry point for the ctx application.
 func main() {
 	if err := cli.Execute(); err != nil {
-		log.Fatalf(errorLogFormat, err)
+		log.Fatalf(utils.ErrorLogFormat, err)
 	}
 }


### PR DESCRIPTION
## Summary
- centralize error log format constant in utils
- use shared constant in main executables

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bc7b032758832788a0545d0ed41196