### PR TITLE
refactor: avoid duplicate MIME detection

### DIFF
--- a/internal/commands/tree.go
+++ b/internal/commands/tree.go
@@ -70,13 +70,13 @@ func buildTreeNodes(currentDirectoryPath string, rootDirectoryPath string, ignor
 				node.Children = childNodes
 			}
 		} else {
-			node.MimeType = utils.DetectMimeType(childPath)
+			detectedMimeType := utils.DetectMimeType(childPath)
 			if utils.IsFileBinary(childPath) {
 				node.Type = types.NodeTypeBinary
 			} else {
 				node.Type = types.NodeTypeFile
 			}
-			node.MimeType = utils.DetectMimeType(childPath)
+			node.MimeType = detectedMimeType
 		}
 		nodes = append(nodes, node)
 	}


### PR DESCRIPTION
## Summary
- compute MIME type once when building tree nodes
- remove redundant utils.DetectMimeType call

## Testing
- `go test ./...`
- `golangci-lint run` *(fails: unsupported version of the configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7b315c6483278e47ce9ff83ec902