### PR TITLE
refactor: clarify index variable in selectFunctionNode

### DIFF
--- a/internal/commands/callchain.go
+++ b/internal/commands/callchain.go
@@ -168,8 +168,8 @@ func composeQualifiedName(pkg *packages.Package, decl *ast.FuncDecl) string {
 // selectFunctionNode finds the graph node matching the candidate function name.
 func selectFunctionNode(graph *callgraph.Graph, candidate string) *callgraph.Node {
 	short := candidate
-	if i := strings.LastIndex(candidate, "."); i >= 0 && i < len(candidate)-1 {
-		short = candidate[i+1:]
+	if lastDotIndex := strings.LastIndex(candidate, "."); lastDotIndex >= 0 && lastDotIndex < len(candidate)-1 {
+		short = candidate[lastDotIndex+1:]
 	}
 	var best *callgraph.Node
 	for _, node := range graph.Nodes {


### PR DESCRIPTION
## Summary
- rename inline variable `i` to `lastDotIndex` in `selectFunctionNode`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bc7d3f34dc8327ab0d8de2fed8b833