### PR TITLE
refactor: improve binary file detection

### DIFF
--- a/internal/utils/binary.go
+++ b/internal/utils/binary.go
@@ -6,7 +6,8 @@ import (
 	"unicode/utf8"
 )
 
-const sniffLen = 8000
+// sniffLength defines the maximum number of bytes read when detecting binary content.
+const sniffLength = 8000
 
 // IsBinary reports whether the provided byte slice appears to contain binary data.
 func IsBinary(data []byte) bool {
@@ -24,18 +25,18 @@ func IsBinary(data []byte) bool {
 	return false
 }
 
-// IsFileBinary reads up to sniffLen bytes from the file at path and determines
+// IsFileBinary reads up to sniffLength bytes from the file at path and determines
 // if the content appears to be binary.
 func IsFileBinary(path string) bool {
-	fileHandle, err := os.Open(path)
-	if err != nil {
+	fileHandle, openError := os.Open(path)
+	if openError != nil {
 		return false
 	}
 	defer fileHandle.Close()
 
-	buffer := make([]byte, sniffLen)
-	bytesRead, err := fileHandle.Read(buffer)
-	if err != nil && err != io.EOF {
+	buffer := make([]byte, sniffLength)
+	bytesRead, readError := fileHandle.Read(buffer)
+	if readError != nil && readError != io.EOF {
 		return false
 	}
 	return IsBinary(buffer[:bytesRead])

--- a/internal/utils/mime.go
+++ b/internal/utils/mime.go
@@ -12,7 +12,7 @@ const (
 )
 
 // DetectMimeType determines the MIME type of the file at the provided path by
-// reading up to sniffLen bytes and passing them to http.DetectContentType. It
+// reading up to sniffLength bytes and passing them to http.DetectContentType. It
 // returns UnknownMimeType if the file cannot be read.
 func DetectMimeType(filePath string) string {
 	openedFile, openError := os.Open(filePath)
@@ -21,7 +21,7 @@ func DetectMimeType(filePath string) string {
 	}
 	defer openedFile.Close()
 
-	buffer := make([]byte, sniffLen)
+	buffer := make([]byte, sniffLength)
 	bytesRead, readError := openedFile.Read(buffer)
 	if readError != nil && readError != io.EOF {
 		return UnknownMimeType


### PR DESCRIPTION
## Summary
- rename sniffLen to sniffLength
- replace err with descriptive openError and readError
- update MIME detection to use new sniffLength constant

## Testing
- `go test ./...` *(fails: command hung and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7d4368788327bd280191498afcdf