### PR TITLE
refactor: rename variables for clarity

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -417,11 +417,11 @@ func runTreeOrContentCommand(
 				documentationEntries = append(documentationEntries, entries...)
 			}
 		}
-		sort.Slice(documentationEntries, func(firstIndex, secondIndex int) bool {
-			if documentationEntries[firstIndex].Kind != documentationEntries[secondIndex].Kind {
-				return documentationEntries[firstIndex].Kind < documentationEntries[secondIndex].Kind
+		sort.Slice(documentationEntries, func(firstEntryIndex, secondEntryIndex int) bool {
+			if documentationEntries[firstEntryIndex].Kind != documentationEntries[secondEntryIndex].Kind {
+				return documentationEntries[firstEntryIndex].Kind < documentationEntries[secondEntryIndex].Kind
 			}
-			return documentationEntries[firstIndex].Name < documentationEntries[secondIndex].Name
+			return documentationEntries[firstEntryIndex].Name < documentationEntries[secondEntryIndex].Name
 		})
 	}
 

--- a/internal/commands/callchain.go
+++ b/internal/commands/callchain.go
@@ -104,21 +104,21 @@ func GetCallChainData(
 	functionSources := make(map[string]string)
 	extractedFilePaths := make(map[string]struct{})
 
-	for _, pkg := range loadedPackages {
-		for _, file := range pkg.Syntax {
+	for _, loadedPackage := range loadedPackages {
+		for _, file := range loadedPackage.Syntax {
 			ast.Inspect(file, func(node ast.Node) bool {
 				funcDecl, ok := node.(*ast.FuncDecl)
 				if !ok || funcDecl.Name == nil {
 					return true
 				}
-				qualifiedName := composeQualifiedName(pkg, funcDecl)
+				qualifiedName := composeQualifiedName(loadedPackage, funcDecl)
 				if _, needed := relevantFunctionNames[qualifiedName]; !needed {
 					return true
 				}
-				var buf bytes.Buffer
+				var functionBuffer bytes.Buffer
 				(&printer.Config{Mode: printer.UseSpaces | printer.TabIndent, Tabwidth: 4}).
-					Fprint(&buf, packageLoadConfiguration.Fset, funcDecl)
-				functionSources[qualifiedName] = buf.String()
+					Fprint(&functionBuffer, packageLoadConfiguration.Fset, funcDecl)
+				functionSources[qualifiedName] = functionBuffer.String()
 				if includeDocumentation {
 					if pos := packageLoadConfiguration.Fset.File(funcDecl.Pos()); pos != nil {
 						extractedFilePaths[pos.Name()] = struct{}{}


### PR DESCRIPTION
## Summary
- rename loop variables for improved readability in call chain extraction
- sort documentation entries using descriptive index names

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bc7d5685a083278507417be5645570