### PR TITLE
Restore root entry point for go install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Improvements ⚙️
+
+* Restore root entry point so `go install github.com/temirov/ctx@latest` works while retaining `cmd/ctx/main.go` for builds.
+
 ## [v0.0.13] - 2025-09-05
 
 ### Highlights

--- a/PRD.md
+++ b/PRD.md
@@ -121,7 +121,9 @@ optional global exclusion flag (`-e`/`--e`). Explicitly listed files are never f
 
 ### Project Structure
 
-- `main.go`: Entry point, argument parsing, path validation, orchestration, output rendering.
+- `main.go`: Entry point for `go install`, delegates to the CLI.
+- `cmd/ctx/main.go`: Entry point for building with `go build ./cmd/ctx`; handles argument parsing, path validation,
+  orchestration, and output rendering.
 - `types/types.go`: Defines shared data structures (`ValidatedPath`, `FileOutput`, `TreeOutputNode`,
   `CallChainOutput`).
 - `config.go`: Loader for ignore files.
@@ -132,7 +134,7 @@ optional global exclusion flag (`-e`/`--e`). Explicitly listed files are never f
 - `output/output.go`: Handles rendering data to JSON or Raw text.
 - `utils/utils.go`: Helper functions (ignore matching, path utils, versioning).
 
-### Step 1: Argument Parsing (`main.go`)
+### Step 1: Argument Parsing (`cmd/ctx/main.go`)
 
 - Update `parseArgsOrExit` to handle `callchain` command and its single argument. Validate argument counts per command.
 - Update `printUsage` to reflect all commands and arguments accurately.
@@ -141,7 +143,7 @@ optional global exclusion flag (`-e`/`--e`). Explicitly listed files are never f
 
 - Define `CallChainOutput` struct with necessary fields and JSON tags.
 
-### Step 3: Path Validation (`main.go`)
+### Step 3: Path Validation (`cmd/ctx/main.go`)
 
 - Keep `resolveAndValidatePaths` for `tree`/`content`. No path validation needed for `callchain` argument itself
   (handled during analysis).
@@ -157,7 +159,7 @@ optional global exclusion flag (`-e`/`--e`). Explicitly listed files are never f
     - Extract source code for relevant functions using `go/ast` and `go/printer`.
     - Return `*types.CallChainOutput` or error.
 
-### Step 5: Orchestration & Data Aggregation (`main.go`)
+### Step 5: Orchestration & Data Aggregation (`cmd/ctx/main.go`)
 
 - **Modify `runTool`** to branch on `types.CommandCallChain`.
     - Call `commands.GetCallChainData`.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ Install and try ctx's core features: directory trees, file contents with optiona
    go install github.com/temirov/ctx@latest
    ```
 
+   Alternatively, build from source in the repository root:
+
+   ```bash
+   go build ./cmd/ctx
+   ```
+
 2. Show a directory tree:
 
    ```bash
@@ -24,7 +30,7 @@ Install and try ctx's core features: directory trees, file contents with optiona
 3. View file content with docs:
 
    ```bash
-   ctx content main.go --doc
+   ctx content cmd/ctx/main.go --doc
    ```
 
 4. Analyze a call chain:
@@ -100,6 +106,12 @@ Pre-built binaries are available on the
    go install github.com/temirov/ctx@latest
    ```
 
+   Alternatively, to build from source in this repository:
+
+   ```bash
+   go build ./cmd/ctx
+   ```
+
 4. Verify:
 
    ```bash
@@ -136,7 +148,7 @@ ctx tree projectA projectB -e dist --format raw
 Output file contents with embedded docs (JSON by default):
 
 ```bash
-ctx content main.go pkg --doc
+ctx content cmd/ctx/main.go pkg --doc
 ```
 
 Analyze the call chain for a function in XML including docs:

--- a/cmd/ctx/main.go
+++ b/cmd/ctx/main.go
@@ -7,9 +7,9 @@ import (
 	"github.com/temirov/ctx/internal/utils"
 )
 
-// main is the entry point for the ctx command.
+// main is the entry point when building the ctx command from the cmd/ctx path.
 func main() {
-	if err := cli.Execute(); err != nil {
-		log.Fatalf(utils.ErrorLogFormat, err)
+	if executionError := cli.Execute(); executionError != nil {
+		log.Fatalf(utils.ErrorLogFormat, executionError)
 	}
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -61,7 +61,7 @@ Use --format to select raw, json, or xml output and --doc to include collected d
   ctx content --doc .
 
   # Display a file in raw format
-  ctx content --format raw main.go`
+  ctx content --format raw cmd/ctx/main.go`
 
 	// callchainLongDescription provides detailed help for the callchain command.
 	callchainLongDescription = `Analyze the call chain of a function.

--- a/main.go
+++ b/main.go
@@ -7,9 +7,9 @@ import (
 	"github.com/temirov/ctx/internal/utils"
 )
 
-// main is the entry point for the ctx application.
+// main is the entry point for installing the ctx command at the module root.
 func main() {
-	if err := cli.Execute(); err != nil {
-		log.Fatalf(utils.ErrorLogFormat, err)
+	if executionError := cli.Execute(); executionError != nil {
+		log.Fatalf(utils.ErrorLogFormat, executionError)
 	}
 }


### PR DESCRIPTION
## Summary
- reinstate root `main.go` that delegates to the CLI so `go install github.com/temirov/ctx@latest` works
- keep `cmd/ctx/main.go` for `go build ./cmd/ctx` and update docs accordingly
- note the dual entry points in PRD and changelog

## Testing
- `go build`
- `go build ./cmd/ctx`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bc810195e883278528545f4de0ca4b