### PR TITLE
refactor: rename documentation error variable

### DIFF
--- a/internal/commands/callchain.go
+++ b/internal/commands/callchain.go
@@ -19,14 +19,13 @@ import (
 	"golang.org/x/tools/go/ssa/ssautil"
 )
 
-
 const (
-  // Error message templates used when retrieving call chain information.
+	// Error message templates used when retrieving call chain information.
 	errorFailedToLoadPackagesFormat      = "failed to load packages: %w"
 	errorEncounteredWhileLoadingPackages = "errors encountered while loading packages"
 	errorFunctionNotFoundFormat          = "target function %q not found in call graph"
-  // qualifiedNameSeparator separates elements in a fully qualified name.
-  qualifiedNameSeparator = "."
+	// qualifiedNameSeparator separates elements in a fully qualified name.
+	qualifiedNameSeparator = "."
 )
 
 // GetCallChainData returns call chain information up to the specified depth.
@@ -154,8 +153,8 @@ func GetCallChainData(
 			if filePath != repositoryRootDirectory && !strings.HasPrefix(filePath, repoPrefix) {
 				continue
 			}
-			entries, err := documentationCollector.CollectFromFile(filePath)
-			if err == nil && len(entries) > 0 {
+			entries, documentationCollectionError := documentationCollector.CollectFromFile(filePath)
+			if documentationCollectionError == nil && len(entries) > 0 {
 				output.Documentation = append(output.Documentation, entries...)
 			}
 		}


### PR DESCRIPTION
## Summary
- rename `err` to `documentationCollectionError` in callchain doc collection

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bca15ac0c88327946b5c2fa720ba88